### PR TITLE
feat: support resetting branch to a specific migration version

### DIFF
--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -552,8 +552,14 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
           'Resets migrations of a development branch. Any untracked data or schema changes will be lost.',
         parameters: z.object({
           branch_id: z.string(),
+          migration_version: z
+            .string()
+            .optional()
+            .describe(
+              'Reset your development branch to a specific migration version.'
+            ),
         }),
-        execute: async ({ branch_id }) => {
+        execute: async ({ branch_id, migration_version }) => {
           const response = await managementApiClient.POST(
             '/v1/branches/{branch_id}/reset',
             {
@@ -562,7 +568,9 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
                   branch_id,
                 },
               },
-              body: {},
+              body: {
+                migration_version,
+              },
             }
           );
 

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -366,9 +366,9 @@ export const mockManagementApi = [
   ),
 
   // Resets a branch and re-runs migrations
-  http.post<{ branchId: string }>(
+  http.post<{ branchId: string }, { migration_version?: string }>(
     `${API_URL}/v1/branches/:branchId/reset`,
-    async ({ params }) => {
+    async ({ params, request }) => {
       const branch = mockBranches.get(params.branchId);
       if (!branch) {
         return HttpResponse.json(
@@ -382,6 +382,15 @@ export const mockManagementApi = [
         return HttpResponse.json(
           { message: 'Project not found' },
           { status: 404 }
+        );
+      }
+
+      // Clear migrations below the specified version
+      const body = await request.json();
+      if (body.migration_version) {
+        const target = body.migration_version;
+        project.migrations = project.migrations.filter(
+          (m) => m.version <= target
         );
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

LLM is able to infer the migration version from a user provided migration name. Explicit version is also supported.

![Screenshot 2025-04-02 at 1 51 36 PM](https://github.com/user-attachments/assets/3772f49e-ee00-4cef-b840-19b5c4b5fbfd)

## Additional context

Add any other context or screenshots.
