### PR TITLE
feat: prompt to clarify project cost

### DIFF
--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -122,7 +122,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       }),
       create_project: tool({
         description:
-          'Creates a new Supabase project. Always ask the user which organization to create the project in. The project can take a few minutes to initialize - use `getProject` to check the status.',
+          'Creates a new Supabase project. Always ask the user which organization to create the project in. Each new project can have additional costs: If on a free org, the user gets 2 projects for free. On a paid org, the user should reference https://supabase.com/pricing. Be sure the user understands this before creating new projects. The project can take a few minutes to initialize - use `getProject` to check the status.',
         parameters: z.object({
           name: z.string().describe('The name of the project'),
           region: z.optional(


### PR DESCRIPTION
Adds prompt to `create_project` description that clarifies the costs involved when creating new projects and asks the LLM to share this with the user before creating new projects.