### PR TITLE
refactor: more explicit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspace @supabase/mcp-utils --workspace @supabase/mcp-server-supabase",
-    "test": "npm run test --workspace @supabase/mcp-server-supabase"
+    "test": "npm run test --workspace @supabase/mcp-utils --workspace @supabase/mcp-server-supabase"
   },
   "devDependencies": {
     "supabase": "^2.1.1"

--- a/packages/mcp-server-supabase/src/util.test.ts
+++ b/packages/mcp-server-supabase/src/util.test.ts
@@ -93,8 +93,6 @@ describe('hashObject', () => {
     const hash1 = await hashObject(obj1);
     const hash2 = await hashObject(obj2);
 
-    console.log('obj1', obj1, hash1);
-
     expect(hash1).not.toBe(hash2);
   });
 });

--- a/packages/mcp-server-supabase/vitest.config.ts
+++ b/packages/mcp-server-supabase/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.ts'],
-    testTimeout: 20_000, // PGlite can take a while to initialize
+    testTimeout: 30_000, // PGlite can take a while to initialize
   },
 });


### PR DESCRIPTION
Removes global mock orgs and projects and instead moves them to each test. This is slightly more verbose but makes testing much clearer and less error prone since each test is responsible for adding mock orgs & projects in the exact states they require prior to performing the test.

For example, we have a bunch of tests that make sure the cost confirmation logic works correctly depending on what payment plan the org is in. It's a lot clearer to define these mock orgs on a per-test basis than globally.