### PR TITLE
Add support for SUPABASE_ACCESS_TOKEN environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Next, configure your MCP client (such as Cursor) to use this server. Most MCP cl
 }
 ```
 
-Replace `<personal-access-token>` with the token you created in step 1. If you are on Windows, you will need to [prefix this command](#windows).
+Replace `<personal-access-token>` with the token you created in step 1. Alternatively you can omit `--access-token` and instead set the `SUPABASE_ACCESS_TOKEN` environment variable to your personal access token (you will need to restart your MCP client after setting this). This allows you to keep your token out of version control if you plan on committing this configuration to a repository.
 
-If your MCP client doesn't accept JSON, the direct CLI command is:
+If you are on Windows, you will need to [prefix the command](#windows). If your MCP client doesn't accept JSON, the direct CLI command is:
 
 ```shell
 npx -y @supabase/mcp-server-supabase@latest --access-token=<personal-access-token>

--- a/packages/mcp-server-supabase/src/stdio.ts
+++ b/packages/mcp-server-supabase/src/stdio.ts
@@ -8,7 +8,7 @@ import { createSupabaseMcpServer } from './server.js';
 async function main() {
   const {
     values: {
-      ['access-token']: accessToken,
+      ['access-token']: cliAccessToken,
       ['api-url']: apiUrl,
       ['version']: showVersion,
     },
@@ -31,9 +31,12 @@ async function main() {
     process.exit(0);
   }
 
+  // Use access token from CLI argument or environment variable
+  const accessToken = cliAccessToken || process.env.SUPABASE_ACCESS_TOKEN;
+
   if (!accessToken) {
     console.error(
-      'Please provide a personal access token (PAT) with the --access-token flag'
+      'Please provide a personal access token (PAT) with the --access-token flag or set the SUPABASE_ACCESS_TOKEN environment variable'
     );
     process.exit(1);
   }

--- a/packages/mcp-server-supabase/src/stdio.ts
+++ b/packages/mcp-server-supabase/src/stdio.ts
@@ -32,7 +32,7 @@ async function main() {
   }
 
   // Use access token from CLI argument or environment variable
-  const accessToken = cliAccessToken || process.env.SUPABASE_ACCESS_TOKEN;
+  const accessToken = cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
 
   if (!accessToken) {
     console.error(


### PR DESCRIPTION
- Allow access token to be set via environment variable (SUPABASE_ACCESS_TOKEN) as an alternative to the CLI flag                                  
- Improves developer experience by allowing tokens to be stored in environment instead of passed on command line       