### PR TITLE
feat: optionally execute query as read only role

### DIFF
--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -40,7 +40,11 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
 
   let managementApiClient: ManagementApiClient;
 
-  async function executeSql<T>(projectId: string, query: string): Promise<T[]> {
+  async function executeSql<T>(
+    projectId: string,
+    query: string,
+    read_only?: boolean
+  ): Promise<T[]> {
     const response = await managementApiClient.POST(
       '/v1/projects/{ref}/database/query',
       {
@@ -51,6 +55,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         },
         body: {
           query,
+          read_only,
         },
       }
     );
@@ -385,9 +390,13 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         parameters: z.object({
           project_id: z.string(),
           query: z.string().describe('The SQL query to execute'),
+          read_only: z
+            .boolean()
+            .optional()
+            .describe('Run query as read-only role instead of postgres role'),
         }),
-        execute: async ({ query, project_id }) => {
-          return await executeSql(project_id, query);
+        execute: async ({ query, project_id, read_only }) => {
+          return await executeSql(project_id, query, read_only);
         },
       }),
       get_logs: tool({


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Schema changes are validated by querying the modified table. Currently it requires an additional confirmation prompt to run the `execute_sql` tool for validation. Since these queries are read-only, it should be safe to run them without confirmation.

## What is the new behavior?

Support `read_only` flag in `execute_sql` tool, paving the way for removing confirmation prompt in the future.

## Additional context

Add any other context or screenshots.
