### PR TITLE
fix: remove system schemas from table list

### DIFF
--- a/packages/mcp-server-supabase/src/pg-meta/index.ts
+++ b/packages/mcp-server-supabase/src/pg-meta/index.ts
@@ -3,6 +3,12 @@ import columnsSql from './columns.sql';
 import extensionsSql from './extensions.sql';
 import tablesSql from './tables.sql';
 
+export const DEFAULT_SYSTEM_SCHEMAS = [
+  'information_schema',
+  'pg_catalog',
+  'pg_toast',
+];
+
 /**
  * Generates the SQL query to list tables in the database.
  */
@@ -19,6 +25,8 @@ export function listTablesSql(schemas: string[] = []) {
 
   if (schemas.length > 0) {
     sql += `  where schema in (${schemas.map((s) => `'${s}'`).join(',')})`;
+  } else {
+    sql += `  where schema not in (${DEFAULT_SYSTEM_SCHEMAS.map((s) => `'${s}'`).join(',')})`;
   }
 
   return sql;

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -705,6 +705,46 @@ describe('tools', () => {
     );
   });
 
+  test('listing all tables excludes system schemas', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const result = await callTool({
+      name: 'list_tables',
+      arguments: {
+        project_id: project.id,
+      },
+    });
+
+    expect(result).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ schema: 'pg_catalog' }),
+      ])
+    );
+
+    expect(result).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ schema: 'information_schema' }),
+      ])
+    );
+
+    expect(result).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ schema: 'pg_toast' })])
+    );
+  });
+
   test('list extensions', async () => {
     const { callTool } = await setup();
 


### PR DESCRIPTION
In #43 we embedded table listing logic from pg-meta, but we forgot to exclude system schemas from the result. This results in a much larger JSON array which tends to use up the entire LLM context limit.

Fixes by excluding system schemas from `list_tables`.