### PR TITLE
Global read only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Make sure Node.js is available in your system `PATH` environment variable. If yo
 
 3. Restart your MCP client.
 
+### Read-only mode
+
+If you wish to restrict the Supabase MCP server to read-only queries, set the `--read-only` flag on the CLI command:
+
+```shell
+npx -y @supabase/mcp-server-supabase@latest --access-token=<personal-access-token> --read-only
+```
+
+This prevents write operations on any of your databases by executing SQL as a read-only Postgres user. Note that this flag only applies to database tools (`execute_sql` and `apply_migration`) and not to other tools like `create_project` or `create_branch`.
+
 ## Tools
 
 _**Note:** This server is pre-1.0, so expect some breaking changes between versions. Since LLMs will automatically adapt to the tools available, this shouldn't affect most users._

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -20,12 +20,27 @@ import {
 import { hashObject } from './util.js';
 
 export type SupabasePlatformOptions = {
-  apiUrl?: string;
+  /**
+   * The access token for the Supabase Management API.
+   */
   accessToken: string;
+
+  /**
+   * The API URL for the Supabase Management API.
+   */
+  apiUrl?: string;
 };
 
 export type SupabaseMcpServerOptions = {
+  /**
+   * Platform options for Supabase.
+   */
   platform: SupabasePlatformOptions;
+
+  /**
+   * Executes database queries in read-only mode if true.
+   */
+  readOnly?: boolean;
 };
 
 /**
@@ -48,6 +63,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         },
         body: {
           query,
+          read_only: options.readOnly,
         },
       }
     );
@@ -331,6 +347,10 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
           query: z.string().describe('The SQL query to apply'),
         }),
         execute: async ({ project_id, name, query }) => {
+          if (options.readOnly) {
+            throw new Error('Cannot apply migration in read-only mode.');
+          }
+
           const response = await managementApiClient.POST(
             '/v1/projects/{ref}/database/migrations',
             {

--- a/packages/mcp-server-supabase/src/stdio.ts
+++ b/packages/mcp-server-supabase/src/stdio.ts
@@ -9,6 +9,7 @@ async function main() {
   const {
     values: {
       ['access-token']: cliAccessToken,
+      ['read-only']: readOnly,
       ['api-url']: apiUrl,
       ['version']: showVersion,
     },
@@ -16,6 +17,10 @@ async function main() {
     options: {
       ['access-token']: {
         type: 'string',
+      },
+      ['read-only']: {
+        type: 'boolean',
+        default: false,
       },
       ['api-url']: {
         type: 'string',
@@ -46,6 +51,7 @@ async function main() {
       accessToken,
       apiUrl,
     },
+    readOnly,
   });
 
   const transport = new StdioServerTransport();


### PR DESCRIPTION
Adds a `--read-only` CLI flag that applies to all database queries (`execute_sql` and `apply_migration`). This is useful for folks who want to connect their AI agents with Supabase for query purposes but don't want to risk AI modifying their database.