### PR TITLE
fix: tool calls with undefined args

### DIFF
--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -340,11 +340,7 @@ export function createMcpServer(options: McpServerOptions) {
         throw new Error('tool not found');
       }
 
-      const args = tool.parameters.parse(request.params.arguments);
-
-      if (!args) {
-        throw new Error('missing arguments');
-      }
+      const args = tool.parameters.parse(request.params.arguments ?? {});
 
       try {
         const result = await tool.execute(args);


### PR DESCRIPTION
Some of our tools take no arguments (eg. `list_organizations`). Typically the expected input for no args is an empty object `{}`, but some clients (eg. Windsurf) pass `undefined` instead. Today our Zod validation will throw an error for `undefined` args (which breaks Windsurf), but there's no technical reason why we shouldn't allow it.

This PR modifies our validation logic to accept both `undefined` and `{}` as "no args".