### PR TITLE
feat: list and deploy edge functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ The following Supabase tools are available to the LLM:
 - `execute_sql`: Executes raw SQL in the database. LLMs should use this for regular queries that don't change the schema.
 - `get_logs`: Gets logs for a Supabase project by service type (api, postgres, edge functions, auth, storage, realtime). LLMs can use this to help with debugging and monitoring service performance.
 
+#### Edge Function Management
+
+- `list_edge_functions`: Lists all Edge Functions in a Supabase project.
+- `deploy_edge_function`: Deploys a new Edge Function to a Supabase project. LLMs can use this to deploy new functions or update existing ones.
+
 #### Project Configuration
 
 - `get_project_url`: Gets the API URL for a project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -194,6 +194,56 @@
         "tough-cookie": "^4.1.4"
       }
     },
+    "node_modules/@deno/eszip": {
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@deno/eszip/-/eszip-0.84.0.tgz",
+      "integrity": "sha512-kfTiJ3jYWy57gV/jjd2McRZdfn2dXHxR3UKL6HQksLAMEmRILHo+pZmN1PAjj8UxQiTBQbybsNHGLaqgHeVntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno": "~0.18.0",
+        "undici": "^6.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno": {
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno/-/shim-deno-0.18.2.tgz",
+      "integrity": "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@deno/shim-deno-test": "^0.5.0",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@deno/shim-deno-test": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@deno/shim-deno-test/-/shim-deno-test-0.5.0.tgz",
+      "integrity": "sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==",
+      "license": "MIT"
+    },
+    "node_modules/@deno/shim-deno/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@deno/shim-deno/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/@electric-sql/pglite": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
@@ -3832,9 +3882,9 @@
       }
     },
     "node_modules/openapi-fetch": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.4.tgz",
-      "integrity": "sha512-JHX7UYjLEiHuQGCPxa3CCCIqe/nc4bTIF9c4UYVC8BegAbWoS3g4gJxKX5XcG7UtYQs2060kY6DH64KkvNZahg==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.5.tgz",
+      "integrity": "sha512-AQK8T9GSKFREFlN1DBXTYsLjs7YV2tZcJ7zUWxbjMoQmj8dDSFRrzhLCbHPZWA1TMV3vACqfCxLEZcwf2wxV6Q==",
       "license": "MIT",
       "dependencies": {
         "openapi-typescript-helpers": "^0.0.15"
@@ -5422,6 +5472,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
@@ -6460,10 +6519,11 @@
       "version": "0.3.5",
       "license": "Apache-2.0",
       "dependencies": {
+        "@deno/eszip": "^0.84.0",
         "@modelcontextprotocol/sdk": "^1.4.1",
         "@supabase/mcp-utils": "0.1.3",
         "common-tags": "^1.8.2",
-        "openapi-fetch": "^0.13.4",
+        "openapi-fetch": "^0.13.5",
         "zod": "^3.24.1"
       },
       "bin": {

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -29,10 +29,11 @@
     }
   },
   "dependencies": {
+    "@deno/eszip": "^0.84.0",
     "@modelcontextprotocol/sdk": "^1.4.1",
     "@supabase/mcp-utils": "0.1.3",
     "common-tags": "^1.8.2",
-    "openapi-fetch": "^0.13.4",
+    "openapi-fetch": "^0.13.5",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/packages/mcp-server-supabase/src/edge-function.ts
+++ b/packages/mcp-server-supabase/src/edge-function.ts
@@ -1,4 +1,10 @@
 import { codeBlock } from 'common-tags';
+import { fileURLToPath } from 'url';
+import { extractFiles } from './eszip.js';
+import {
+  assertSuccess,
+  type ManagementApiClient,
+} from './management-api/index.js';
 
 /**
  * Gets the deployment ID for an Edge Function.
@@ -34,3 +40,90 @@ export const edgeFunctionExample = codeBlock`
     });
   });
 `;
+
+/**
+ * Fetches a full Edge Function from the Supabase Management API.
+
+ * - Includes both function metadata and the contents of each file.
+ * - Normalizes file paths to be relative to the project root.
+ */
+export async function getFullEdgeFunction(
+  managementApiClient: ManagementApiClient,
+  projectId: string,
+  functionSlug: string
+) {
+  const functionResponse = await managementApiClient.GET(
+    '/v1/projects/{ref}/functions/{function_slug}',
+    {
+      params: {
+        path: {
+          ref: projectId,
+          function_slug: functionSlug,
+        },
+      },
+    }
+  );
+
+  if (functionResponse.error) {
+    return {
+      data: undefined,
+      error: functionResponse.error as { message: string },
+    };
+  }
+
+  assertSuccess(functionResponse, 'Failed to fetch Edge Function');
+
+  const edgeFunction = functionResponse.data;
+
+  const deploymentId = getDeploymentId(
+    projectId,
+    edgeFunction.id,
+    edgeFunction.version
+  );
+
+  const pathPrefix = getPathPrefix(deploymentId);
+
+  const entrypoint_path = edgeFunction.entrypoint_path
+    ? fileURLToPath(edgeFunction.entrypoint_path).replace(pathPrefix, '')
+    : undefined;
+
+  const import_map_path = edgeFunction.import_map_path
+    ? fileURLToPath(edgeFunction.import_map_path).replace(pathPrefix, '')
+    : undefined;
+
+  const eszipResponse = await managementApiClient.GET(
+    '/v1/projects/{ref}/functions/{function_slug}/body',
+    {
+      params: {
+        path: {
+          ref: projectId,
+          function_slug: functionSlug,
+        },
+      },
+      parseAs: 'arrayBuffer',
+    }
+  );
+
+  assertSuccess(eszipResponse, 'Failed to fetch Edge Function eszip bundle');
+
+  const extractedFiles = await extractFiles(
+    new Uint8Array(eszipResponse.data),
+    pathPrefix
+  );
+
+  const files = await Promise.all(
+    extractedFiles.map(async (file) => ({
+      name: file.name,
+      content: await file.text(),
+    }))
+  );
+
+  const normalizedFunction = {
+    ...edgeFunction,
+    entrypoint_path,
+    import_map_path,
+    files,
+  };
+
+  return { data: normalizedFunction, error: undefined };
+}

--- a/packages/mcp-server-supabase/src/edge-function.ts
+++ b/packages/mcp-server-supabase/src/edge-function.ts
@@ -1,0 +1,17 @@
+/**
+ * Gets the deployment ID for an Edge Function.
+ */
+export function getDeploymentId(
+  projectId: string,
+  functionId: string,
+  functionVersion: number
+): string {
+  return `${projectId}_${functionId}_${functionVersion}`;
+}
+
+/**
+ * Gets the path prefix applied to each file in an Edge Function.
+ */
+export function getPathPrefix(deploymentId: string) {
+  return `/tmp/user_fn_${deploymentId}/`;
+}

--- a/packages/mcp-server-supabase/src/edge-function.ts
+++ b/packages/mcp-server-supabase/src/edge-function.ts
@@ -1,3 +1,5 @@
+import { codeBlock } from 'common-tags';
+
 /**
  * Gets the deployment ID for an Edge Function.
  */
@@ -15,3 +17,20 @@ export function getDeploymentId(
 export function getPathPrefix(deploymentId: string) {
   return `/tmp/user_fn_${deploymentId}/`;
 }
+
+export const edgeFunctionExample = codeBlock`
+  import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+  Deno.serve(async (req: Request) => {
+    const data = {
+      message: "Hello there!"
+    };
+    
+    return new Response(JSON.stringify(data), {
+      headers: {
+        'Content-Type': 'application/json',
+        'Connection': 'keep-alive'
+      }
+    });
+  });
+`;

--- a/packages/mcp-server-supabase/src/eszip.test.ts
+++ b/packages/mcp-server-supabase/src/eszip.test.ts
@@ -1,0 +1,100 @@
+import { codeBlock } from 'common-tags';
+import { open, type FileHandle } from 'node:fs/promises';
+import { describe, expect, test } from 'vitest';
+import { bundleFiles, extractFiles } from './eszip.js';
+
+describe('eszip', () => {
+  test('extract files', async () => {
+    const helloContent = codeBlock`
+      export function hello(): string {
+        return 'Hello, world!';
+      }
+    `;
+    const helloFile = new File([helloContent], 'hello.ts', {
+      type: 'application/typescript',
+    });
+
+    const indexContent = codeBlock`
+      import { hello } from './hello.ts';
+
+      Deno.serve(async (req: Request) => {
+        return new Response(hello(), { headers: { 'Content-Type': 'text/plain' } })
+      });
+    `;
+    const indexFile = new File([indexContent], 'index.ts', {
+      type: 'application/typescript',
+    });
+
+    const eszip = await bundleFiles([indexFile, helloFile]);
+    const extractedFiles = await extractFiles(eszip);
+
+    expect(extractedFiles).toHaveLength(2);
+
+    const extractedIndexFile = extractedFiles.find(
+      (file) => file.name === 'index.ts'
+    );
+    const extractedHelloFile = extractedFiles.find(
+      (file) => file.name === 'hello.ts'
+    );
+
+    expect(extractedIndexFile).toBeDefined();
+    expect(extractedIndexFile!.type).toBe('application/typescript');
+    await expect(extractedIndexFile!.text()).resolves.toBe(indexContent);
+
+    expect(extractedHelloFile).toBeDefined();
+    expect(extractedHelloFile!.type).toBe('application/typescript');
+    await expect(extractedHelloFile!.text()).resolves.toBe(helloContent);
+  });
+});
+
+export class Source implements UnderlyingSource<Uint8Array> {
+  type = 'bytes' as const;
+  autoAllocateChunkSize = 1024;
+
+  path: string | URL;
+  controller?: ReadableByteStreamController;
+  file?: FileHandle;
+
+  constructor(path: string | URL) {
+    this.path = path;
+  }
+
+  async start(controller: ReadableStreamController<Uint8Array>) {
+    if (!('byobRequest' in controller)) {
+      throw new Error('ReadableStreamController does not support byobRequest');
+    }
+
+    this.file = await open(this.path);
+    this.controller = controller;
+  }
+
+  async pull() {
+    console.log('Pulling data...');
+    if (!this.controller || !this.file) {
+      throw new Error('ReadableStream has not been started');
+    }
+
+    if (!this.controller.byobRequest) {
+      throw new Error('ReadableStreamController does not support byobRequest');
+    }
+
+    const view = this.controller.byobRequest.view as NodeJS.ArrayBufferView;
+
+    if (!view) {
+      throw new Error('ReadableStreamController does not have a view');
+    }
+
+    const { bytesRead } = await this.file.read({
+      buffer: view,
+      offset: view.byteOffset,
+      length: view.byteLength,
+    });
+
+    if (bytesRead === 0) {
+      await this.file.close();
+      this.controller.close();
+    }
+
+    this.controller.byobRequest.respond(view.byteLength);
+  }
+}

--- a/packages/mcp-server-supabase/src/eszip.test.ts
+++ b/packages/mcp-server-supabase/src/eszip.test.ts
@@ -69,7 +69,6 @@ export class Source implements UnderlyingSource<Uint8Array> {
   }
 
   async pull() {
-    console.log('Pulling data...');
     if (!this.controller || !this.file) {
       throw new Error('ReadableStream has not been started');
     }

--- a/packages/mcp-server-supabase/src/eszip.ts
+++ b/packages/mcp-server-supabase/src/eszip.ts
@@ -1,0 +1,108 @@
+import { build, Parser } from '@deno/eszip';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const parser = await Parser.createInstance();
+const sourceMapSchema = z.object({
+  version: z.number(),
+  sources: z.array(z.string()),
+  sourcesContent: z.array(z.string()).optional(),
+  names: z.array(z.string()),
+  mappings: z.string(),
+});
+
+/**
+ * Extracts source files from an eszip archive.
+ *
+ * Optionally removes the given path prefix from file names.
+ *
+ * If a file contains a source map, it will return the
+ * original TypeScript source instead of the transpiled file.
+ */
+export async function extractFiles(
+  eszip: Uint8Array,
+  pathPrefix: string = '/'
+) {
+  let specifiers: string[] = [];
+
+  if (eszip instanceof ReadableStream) {
+    const reader = eszip.getReader({ mode: 'byob' });
+    specifiers = await parser.parse(reader);
+  } else {
+    specifiers = await parser.parseBytes(eszip);
+  }
+
+  await parser.load();
+
+  const fileSpecifiers = specifiers.filter((specifier) =>
+    specifier.startsWith('file://')
+  );
+
+  const files = await Promise.all(
+    fileSpecifiers.map(async (specifier) => {
+      const source: string = await parser.getModuleSource(specifier);
+      const sourceMapString: string =
+        await parser.getModuleSourceMap(specifier);
+
+      const filePath = relative(pathPrefix, fileURLToPath(specifier));
+
+      const file = new File([source], filePath, {
+        type: 'text/plain',
+      });
+
+      if (!sourceMapString) {
+        return file;
+      }
+
+      const sourceMap = sourceMapSchema.parse(JSON.parse(sourceMapString));
+
+      const [typeScriptSource] = sourceMap.sourcesContent ?? [];
+
+      if (!typeScriptSource) {
+        return file;
+      }
+
+      const sourceFile = new File([typeScriptSource], filePath, {
+        type: 'application/typescript',
+      });
+
+      return sourceFile;
+    })
+  );
+
+  return files;
+}
+
+/**
+ * Bundles files into an eszip archive.
+ *
+ * Optionally prefixes the file names with a given path.
+ */
+export async function bundleFiles(files: File[], pathPrefix: string = '/') {
+  const specifiers = files.map(
+    (file) => `file://${join(pathPrefix, file.name)}`
+  );
+  const eszip = await build(specifiers, async (specifier: string) => {
+    if (specifier.startsWith('file://')) {
+      const file = files.find(
+        (file) => `file://${join(pathPrefix, file.name)}` === specifier
+      );
+
+      if (!file) {
+        throw new Error(`File not found: ${specifier}`);
+      }
+
+      return {
+        kind: 'module',
+        specifier,
+        headers: {
+          'content-type': file.type,
+        },
+        content: await file.text(),
+      };
+    }
+  });
+
+  return eszip;
+}

--- a/packages/mcp-server-supabase/src/management-api/index.ts
+++ b/packages/mcp-server-supabase/src/management-api/index.ts
@@ -19,7 +19,6 @@ export function createManagementApiClient(
   return createClient<paths>({
     baseUrl,
     headers: {
-      'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
       ...headers,
     },
@@ -53,7 +52,7 @@ export function assertSuccess<
   if ('error' in response) {
     if (response.response.status === 401) {
       throw new Error(
-        'Unauthorized. Please provide a valid access token to the MCP server via the --access-token flag.'
+        'Unauthorized. Please provide a valid access token to the MCP server via the --access-token flag or SUPABASE_ACCESS_TOKEN.'
       );
     }
 

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4,6 +4,7 @@ import {
   type CallToolRequest,
 } from '@modelcontextprotocol/sdk/types.js';
 import { StreamTransport } from '@supabase/mcp-utils';
+import { codeBlock } from 'common-tags';
 import { setupServer } from 'msw/node';
 import { beforeEach, describe, expect, test } from 'vitest';
 import {
@@ -884,9 +885,7 @@ describe('tools', () => {
       arguments: {},
     });
 
-    await expect(listOrganizationsPromise).rejects.toThrow(
-      'Unauthorized. Please provide a valid access token to the MCP server via the --access-token flag.'
-    );
+    await expect(listOrganizationsPromise).rejects.toThrow('Unauthorized.');
   });
 
   test('invalid sql for apply_migration', async () => {
@@ -1017,6 +1016,198 @@ describe('tools', () => {
       },
     });
     await expect(getLogsPromise).rejects.toThrow('Invalid enum value');
+  });
+
+  test('list edge functions', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const indexContent = codeBlock`
+      Deno.serve(async (req: Request) => {
+        return new Response('Hello world!', { headers: { 'Content-Type': 'text/plain' } })
+      });
+    `;
+
+    const edgeFunction = await project.deployEdgeFunction(
+      {
+        name: 'hello-world',
+        entrypoint_path: 'index.ts',
+      },
+      [
+        new File([indexContent], 'index.ts', {
+          type: 'application/typescript',
+        }),
+      ]
+    );
+
+    const result = await callTool({
+      name: 'list_edge_functions',
+      arguments: {
+        project_id: project.id,
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        id: edgeFunction.id,
+        slug: edgeFunction.slug,
+        version: edgeFunction.version,
+        name: edgeFunction.name,
+        status: edgeFunction.status,
+        entrypoint_path: 'index.ts',
+        import_map_path: null,
+        import_map: false,
+        verify_jwt: true,
+        created_at: expect.stringMatching(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+        ),
+        updated_at: expect.stringMatching(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+        ),
+        files: [
+          {
+            name: 'index.ts',
+            content: indexContent,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('deploy new edge function', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const functionName = 'hello-world';
+    const functionCode = 'console.log("Hello, world!");';
+
+    const result = await callTool({
+      name: 'deploy_edge_function',
+      arguments: {
+        project_id: project.id,
+        name: functionName,
+        files: [
+          {
+            name: 'index.ts',
+            content: functionCode,
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      id: expect.stringMatching(/^.+$/),
+      slug: functionName,
+      version: 1,
+      name: functionName,
+      status: 'ACTIVE',
+      entrypoint_path: expect.stringMatching(/index\.ts$/),
+      import_map_path: null,
+      import_map: false,
+      verify_jwt: true,
+      created_at: expect.stringMatching(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+      ),
+      updated_at: expect.stringMatching(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+      ),
+    });
+  });
+
+  test('deploy new version of existing edge function', async () => {
+    const { callTool } = await setup();
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const functionName = 'hello-world';
+
+    const edgeFunction = await project.deployEdgeFunction(
+      {
+        name: functionName,
+        entrypoint_path: 'index.ts',
+      },
+      [
+        new File(['console.log("Hello, world!");'], 'index.ts', {
+          type: 'application/typescript',
+        }),
+      ]
+    );
+
+    expect(edgeFunction.version).toEqual(1);
+
+    const originalCreatedAt = edgeFunction.created_at.getTime();
+    const originalUpdatedAt = edgeFunction.updated_at.getTime();
+
+    const result = await callTool({
+      name: 'deploy_edge_function',
+      arguments: {
+        project_id: project.id,
+        name: functionName,
+        files: [
+          {
+            name: 'index.ts',
+            content: 'console.log("Hello, world! v2");',
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      id: edgeFunction.id,
+      slug: functionName,
+      version: 2,
+      name: functionName,
+      status: 'ACTIVE',
+      entrypoint_path: expect.stringMatching(/index\.ts$/),
+      import_map_path: null,
+      import_map: false,
+      verify_jwt: true,
+      created_at: expect.stringMatching(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+      ),
+      updated_at: expect.stringMatching(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
+      ),
+    });
+
+    expect(new Date(result.created_at).getTime()).toEqual(originalCreatedAt);
+    expect(new Date(result.updated_at).getTime()).toBeGreaterThan(
+      originalUpdatedAt
+    );
   });
 
   test('create branch', async () => {

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -2,7 +2,11 @@ import { createMcpServer, tool } from '@supabase/mcp-utils';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import packageJson from '../package.json' with { type: 'json' };
-import { getDeploymentId, getPathPrefix } from './edge-function.js';
+import {
+  edgeFunctionExample,
+  getDeploymentId,
+  getPathPrefix,
+} from './edge-function.js';
 import { extractFiles } from './eszip.js';
 import { getLogQuery } from './logs.js';
 import {
@@ -465,8 +469,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         },
       }),
       deploy_edge_function: tool({
-        description:
-          'Deploys an Edge Function to a Supabase project. If the function already exists, this will create a new version.',
+        description: `Deploys an Edge Function to a Supabase project. If the function already exists, this will create a new version. Example:\n\n${edgeFunctionExample}`,
         parameters: z.object({
           project_id: z.string(),
           name: z.string().describe('The name of the function'),

--- a/packages/mcp-server-supabase/src/stdio.ts
+++ b/packages/mcp-server-supabase/src/stdio.ts
@@ -2,8 +2,10 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { parseArgs } from 'node:util';
-import { version } from '../package.json';
+import packageJson from '../package.json' with { type: 'json' };
 import { createSupabaseMcpServer } from './server.js';
+
+const { version } = packageJson;
 
 async function main() {
   const {

--- a/packages/mcp-server-supabase/test/extensions.ts
+++ b/packages/mcp-server-supabase/test/extensions.ts
@@ -17,7 +17,7 @@ expect.extend({
         reason: z
           .string()
           .describe(
-            "The reason why 'Received' does or does not adhere to the test 'Criteria'. Must explain exactly which part of 'Received' did or did not pass the test 'Criteria'."
+            "The reason why 'Received' does or does not adhere to the test 'Criteria'. Keep concise while explaining exactly which part of 'Received' did or did not pass the test 'Criteria'."
           ),
       }),
       messages: [

--- a/packages/mcp-server-supabase/test/llm.e2e.ts
+++ b/packages/mcp-server-supabase/test/llm.e2e.ts
@@ -238,8 +238,6 @@ describe('llm tests', () => {
       expect.objectContaining({ toolName: 'deploy_edge_function' })
     );
 
-    console.log(text);
-
     await expect(text).toMatchCriteria(
       'Confirms the successful modification of an Edge Function.'
     );

--- a/packages/mcp-server-supabase/test/llm.e2e.ts
+++ b/packages/mcp-server-supabase/test/llm.e2e.ts
@@ -89,10 +89,11 @@ describe('llm tests', () => {
       .sql`create table inventory (id serial, name text)`;
 
     const toolCalls: ToolCallUnion<ToolSet>[] = [];
+    const tools = await client.tools();
 
     const { text } = await generateText({
       model,
-      tools: await client.tools(),
+      tools,
       messages: [
         {
           role: 'system',
@@ -104,7 +105,7 @@ describe('llm tests', () => {
           content: 'What tables do I have?',
         },
       ],
-      maxSteps: 2,
+      maxSteps: 3,
       async onStepFinish({ toolCalls: tools }) {
         toolCalls.push(...tools);
       },
@@ -140,10 +141,11 @@ describe('llm tests', () => {
     });
 
     const toolCalls: ToolCallUnion<ToolSet>[] = [];
+    const tools = await client.tools();
 
     const { text } = await generateText({
       model,
-      tools: await client.tools(),
+      tools,
       messages: [
         {
           role: 'system',
@@ -156,7 +158,7 @@ describe('llm tests', () => {
         },
       ],
       maxSteps: 2,
-      async onStepFinish({ text, toolCalls: tools, toolResults }) {
+      async onStepFinish({ toolCalls: tools }) {
         toolCalls.push(...tools);
       },
     });
@@ -206,10 +208,11 @@ describe('llm tests', () => {
     );
 
     const toolCalls: ToolCallUnion<ToolSet>[] = [];
+    const tools = await client.tools();
 
     const { text } = await generateText({
       model,
-      tools: await client.tools(),
+      tools,
       messages: [
         {
           role: 'system',
@@ -222,11 +225,8 @@ describe('llm tests', () => {
         },
       ],
       maxSteps: 3,
-      async onStepFinish({ text, toolCalls: tools, toolResults }) {
+      async onStepFinish({ toolCalls: tools }) {
         toolCalls.push(...tools);
-        console.dir(text, { depth: null });
-        console.dir(tools, { depth: null });
-        console.dir(toolResults, { depth: null });
       },
     });
 

--- a/packages/mcp-server-supabase/test/llm.e2e.ts
+++ b/packages/mcp-server-supabase/test/llm.e2e.ts
@@ -1,13 +1,17 @@
+/// <reference types="./extensions.d.ts" />
+
 import { anthropic } from '@ai-sdk/anthropic';
 import { StreamTransport } from '@supabase/mcp-utils';
 import {
   experimental_createMCPClient as createMCPClient,
   generateText,
-  ToolSet,
   type ToolCallUnion,
+  type ToolSet,
 } from 'ai';
+import { codeBlock } from 'common-tags';
 import { setupServer } from 'msw/node';
 import { beforeEach, describe, expect, test } from 'vitest';
+import { extractFiles } from '../src/eszip.js';
 import { createSupabaseMcpServer } from '../src/index.js';
 import {
   ACCESS_TOKEN,
@@ -100,7 +104,7 @@ describe('llm tests', () => {
           content: 'What tables do I have?',
         },
       ],
-      maxSteps: 10,
+      maxSteps: 2,
       async onStepFinish({ toolCalls: tools }) {
         toolCalls.push(...tools);
       },
@@ -117,5 +121,140 @@ describe('llm tests', () => {
     await expect(text).toMatchCriteria(
       'Describes a single table in the "todos-app" project called "todos"'
     );
+  });
+
+  test('deploys an edge function', async () => {
+    const { client } = await setup();
+    const model = anthropic('claude-3-7-sonnet-20250219');
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'todos-app',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+
+    const toolCalls: ToolCallUnion<ToolSet>[] = [];
+
+    const { text } = await generateText({
+      model,
+      tools: await client.tools(),
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a coding assistant. The current working directory is /home/user/projects/todos-app.',
+        },
+        {
+          role: 'user',
+          content: `Deploy an edge function to project with ref ${project.id} that returns the current time in UTC.`,
+        },
+      ],
+      maxSteps: 2,
+      async onStepFinish({ text, toolCalls: tools, toolResults }) {
+        toolCalls.push(...tools);
+      },
+    });
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toEqual(
+      expect.objectContaining({ toolName: 'deploy_edge_function' })
+    );
+
+    await expect(text).toMatchCriteria(
+      'Confirms the successful deployment of an edge function that will return the current time in UTC. It describes steps to test the function.'
+    );
+  });
+
+  test('modifies an edge function', async () => {
+    const { client } = await setup();
+    const model = anthropic('claude-3-7-sonnet-20250219');
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'todos-app',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+
+    const code = codeBlock`
+      Deno.serve(async (req: Request) => {
+        return new Response('Hello world!', { headers: { 'Content-Type': 'text/plain' } })
+      })
+    `;
+
+    const edgeFunction = await project.deployEdgeFunction(
+      {
+        name: 'hello-world',
+        entrypoint_path: 'index.ts',
+      },
+      [
+        new File([code], 'index.ts', {
+          type: 'application/typescript',
+        }),
+      ]
+    );
+
+    const toolCalls: ToolCallUnion<ToolSet>[] = [];
+
+    const { text } = await generateText({
+      model,
+      tools: await client.tools(),
+      messages: [
+        {
+          role: 'system',
+          content:
+            'You are a coding assistant. The current working directory is /home/user/projects/todos-app.',
+        },
+        {
+          role: 'user',
+          content: `Change my edge function (project id ${project.id}) to replace "world" with "Earth".`,
+        },
+      ],
+      maxSteps: 3,
+      async onStepFinish({ text, toolCalls: tools, toolResults }) {
+        toolCalls.push(...tools);
+        console.dir(text, { depth: null });
+        console.dir(tools, { depth: null });
+        console.dir(toolResults, { depth: null });
+      },
+    });
+
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]).toEqual(
+      expect.objectContaining({ toolName: 'list_edge_functions' })
+    );
+    expect(toolCalls[1]).toEqual(
+      expect.objectContaining({ toolName: 'deploy_edge_function' })
+    );
+
+    console.log(text);
+
+    await expect(text).toMatchCriteria(
+      'Confirms the successful modification of an Edge Function.'
+    );
+
+    const files = await extractFiles(
+      edgeFunction.eszip!,
+      edgeFunction.pathPrefix
+    );
+
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe('index.ts');
+    await expect(files[0].text()).resolves.toEqual(codeBlock`
+      Deno.serve(async (req: Request) => {
+        return new Response('Hello Earth!', { headers: { 'Content-Type': 'text/plain' } })
+      })
+    `);
   });
 });

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -2,11 +2,16 @@ import { PGlite, type PGliteInterface } from '@electric-sql/pglite';
 import { format } from 'date-fns';
 import { http, HttpResponse } from 'msw';
 import { customAlphabet } from 'nanoid';
+import { join } from 'node:path';
 import { expect } from 'vitest';
 import { z } from 'zod';
-import { version } from '../package.json';
-import type { components } from '../src/management-api/types';
+import packageJson from '../package.json' with { type: 'json' };
+import { getDeploymentId, getPathPrefix } from '../src/edge-function.js';
+import { bundleFiles } from '../src/eszip.js';
+import type { components } from '../src/management-api/types.js';
 import { TRACE_URL } from '../src/regions.js';
+
+const { version } = packageJson;
 
 const nanoid = customAlphabet('abcdefghijklmnopqrstuvwxyz', 20);
 
@@ -217,6 +222,107 @@ export const mockManagementApi = [
       }
 
       return HttpResponse.json(lastStatementResults.rows);
+    }
+  ),
+
+  /**
+   * Lists all Edge Functions for a project
+   */
+  http.get<{ projectId: string }>(
+    `${API_URL}/v1/projects/:projectId/functions`,
+    ({ params }) => {
+      const project = mockProjects.get(params.projectId);
+      if (!project) {
+        return HttpResponse.json(
+          { message: 'Project not found' },
+          { status: 404 }
+        );
+      }
+
+      return HttpResponse.json(
+        Array.from(project.edge_functions.values()).map(
+          (edgeFunction) => edgeFunction.details
+        )
+      );
+    }
+  ),
+
+  /**
+   * Gets the eszip bundle for an Edge Function
+   */
+  http.get<{ projectId: string; functionSlug: string }>(
+    `${API_URL}/v1/projects/:projectId/functions/:functionSlug/body`,
+    ({ params }) => {
+      const project = mockProjects.get(params.projectId);
+      if (!project) {
+        return HttpResponse.json(
+          { message: 'Project not found' },
+          { status: 404 }
+        );
+      }
+
+      const edgeFunction = project.edge_functions.get(params.functionSlug);
+      if (!edgeFunction) {
+        return HttpResponse.json(
+          { message: 'Edge Function not found' },
+          { status: 404 }
+        );
+      }
+
+      if (!edgeFunction.eszip) {
+        return HttpResponse.json(
+          { message: 'Edge Function files not found' },
+          { status: 404 }
+        );
+      }
+
+      return HttpResponse.arrayBuffer(edgeFunction.eszip);
+    }
+  ),
+  /**
+   * Deploys an Edge Function
+   */
+  http.post<{ projectId: string }>(
+    `${API_URL}/v1/projects/:projectId/functions/deploy`,
+    async ({ params, request }) => {
+      const project = mockProjects.get(params.projectId);
+      if (!project) {
+        return HttpResponse.json(
+          { message: 'Project not found' },
+          { status: 404 }
+        );
+      }
+      const formData = await request.formData();
+
+      const metadataSchema = z.object({
+        name: z.string(),
+        entrypoint_path: z.string(),
+      });
+
+      const metadataFormValue = formData.get('metadata');
+      const metadataString =
+        metadataFormValue instanceof File
+          ? await metadataFormValue.text()
+          : (metadataFormValue ?? undefined);
+
+      if (!metadataString) {
+        throw new Error('Metadata is required');
+      }
+
+      const metadata = metadataSchema.parse(JSON.parse(metadataString));
+
+      const fileFormValues = formData.getAll('file');
+
+      const files = fileFormValues.map((file) => {
+        if (typeof file === 'string') {
+          throw new Error('Multipart file is a string instead of a File');
+        }
+        return file;
+      });
+
+      const edgeFunction = await project.deployEdgeFunction(metadata, files);
+
+      return HttpResponse.json(edgeFunction.details);
     }
   ),
 
@@ -639,6 +745,81 @@ export class MockOrganization {
   }
 }
 
+export type MockEdgeFunctionOptions = {
+  name: string;
+  entrypoint_path: string;
+};
+
+export class MockEdgeFunction {
+  projectId: string;
+  id: string;
+  slug: string;
+  version: number;
+  name: string;
+  status: 'ACTIVE' | 'REMOVED' | 'THROTTLED';
+  entrypoint_path: string;
+  import_map_path: string | null;
+  import_map: boolean;
+  verify_jwt: boolean;
+  created_at: Date;
+  updated_at: Date;
+
+  eszip?: Uint8Array;
+
+  async setFiles(files: File[]) {
+    this.eszip = await bundleFiles(files, this.pathPrefix);
+  }
+
+  get deploymentId() {
+    return getDeploymentId(this.projectId, this.id, this.version);
+  }
+
+  get pathPrefix() {
+    return getPathPrefix(this.deploymentId);
+  }
+
+  get details() {
+    return {
+      id: this.id,
+      slug: this.slug,
+      version: this.version,
+      name: this.name,
+      status: this.status,
+      entrypoint_path: this.entrypoint_path,
+      import_map_path: this.import_map_path,
+      import_map: this.import_map,
+      verify_jwt: this.verify_jwt,
+      created_at: this.created_at.toISOString(),
+      updated_at: this.updated_at.toISOString(),
+    };
+  }
+
+  constructor(
+    projectId: string,
+    { name, entrypoint_path }: MockEdgeFunctionOptions
+  ) {
+    this.projectId = projectId;
+    this.id = crypto.randomUUID();
+    this.slug = name;
+    this.version = 1;
+    this.name = name;
+    this.status = 'ACTIVE';
+    this.entrypoint_path = `file://${join(this.pathPrefix, entrypoint_path)}`;
+    this.import_map_path = null;
+    this.import_map = false;
+    this.verify_jwt = true;
+    this.created_at = new Date();
+    this.updated_at = new Date();
+  }
+
+  update({ name, entrypoint_path }: MockEdgeFunctionOptions) {
+    this.name = name;
+    this.version += 1;
+    this.entrypoint_path = `file://${join(this.pathPrefix, entrypoint_path)}`;
+    this.updated_at = new Date();
+  }
+}
+
 export type MockProjectOptions = {
   name: string;
   region: string;
@@ -660,6 +841,7 @@ export class MockProject {
   };
 
   migrations: Migration[] = [];
+  edge_functions = new Map<string, MockEdgeFunction>();
 
   #db?: PGliteInterface;
 
@@ -721,6 +903,25 @@ export class MockProject {
     }
     this.#db = undefined;
     return this.db;
+  }
+
+  async deployEdgeFunction(
+    options: MockEdgeFunctionOptions,
+    files: File[] = []
+  ) {
+    const edgeFunction = new MockEdgeFunction(this.id, options);
+    const existingFunction = this.edge_functions.get(edgeFunction.slug);
+
+    if (existingFunction) {
+      existingFunction.update(options);
+      await existingFunction.setFiles(files);
+      return existingFunction;
+    }
+
+    await edgeFunction.setFiles(files);
+    this.edge_functions.set(edgeFunction.slug, edgeFunction);
+
+    return edgeFunction;
   }
 
   async destroy() {

--- a/packages/mcp-server-supabase/tsconfig.json
+++ b/packages/mcp-server-supabase/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom/library",
+  "extends": "@total-typescript/tsconfig/tsc/dom/library",
   "include": ["src/**/*.ts"]
 }

--- a/packages/mcp-server-supabase/vitest.workspace.ts
+++ b/packages/mcp-server-supabase/vitest.workspace.ts
@@ -31,7 +31,7 @@ export default defineWorkspace([
       name: 'e2e',
       include: ['test/**/*.e2e.ts'],
       setupFiles: ['./vitest.setup.ts'],
-      testTimeout: 30_000,
+      testTimeout: 60_000,
     },
   },
 ]);


### PR DESCRIPTION
Adds Edge Function support via 2 new tools:
- `list_edge_functions`: List all Edge Functions for a project including source files for each.
- `deploy_edge_function`: Deploys an Edge Function. If the specified slug is unique, a new Edge Function will be deployed. Otherwise this will deploy a new version of an existing function.

For now we opted to include source files (eg. `index.ts`) in the `list_edge_functions` call vs. create another detailed `get_edge_function` tool to reduce the number of tools needed. The rationale is that many functions end up living in only a single `index.ts` file, so the overhead of pulling this for every function is not excessive for most people. This might change in the future, but this is a good starting point and can keep tool count down.