### PR TITLE
chore: add coverage reporting via coveralls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,4 +21,8 @@ jobs:
       - name: Build libs
         run: npm run build
       - name: Tests
-        run: npm run test
+        run: npm run test:coverage
+      - name: Upload coverage results to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: ./packages/mcp-server-supabase

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Build libs
-        run: npm run build
+        run: |
+          npm run build
+          npm rebuild # To create bin links
       - name: Tests
         run: npm run test:coverage
       - name: Upload coverage results to Coveralls

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,20 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -162,6 +176,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
@@ -850,6 +871,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2073,6 +2104,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -3215,6 +3279,16 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -3225,6 +3299,13 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3363,6 +3444,89 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3515,6 +3679,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -4744,6 +4920,21 @@
         "minizlib": "^3.0.1",
         "mkdirp": "^3.0.1",
         "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
       },
       "engines": {
         "node": ">=18"
@@ -6535,6 +6726,7 @@
         "@total-typescript/tsconfig": "^1.0.4",
         "@types/common-tags": "^1.8.4",
         "@types/node": "^22.8.6",
+        "@vitest/coverage-v8": "^2.1.9",
         "ai": "^4.3.4",
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   ],
   "scripts": {
     "build": "npm run build --workspace @supabase/mcp-utils --workspace @supabase/mcp-server-supabase",
-    "test": "npm run test --workspace @supabase/mcp-utils --workspace @supabase/mcp-server-supabase"
+    "test": "npm run test --workspace @supabase/mcp-utils --workspace @supabase/mcp-server-supabase",
+    "test:coverage": "npm run test:coverage --workspace @supabase/mcp-server-supabase"
   },
   "devDependencies": {
     "supabase": "^2.1.1"

--- a/packages/mcp-server-supabase/.gitignore
+++ b/packages/mcp-server-supabase/.gitignore
@@ -1,0 +1,1 @@
+test/coverage

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -11,8 +11,9 @@
     "build": "tsup --clean",
     "prepublishOnly": "npm run build",
     "test": "vitest",
-    "test:e2e": "vitest --project e2e",
     "test:unit": "vitest --project unit",
+    "test:e2e": "vitest --project e2e",
+    "test:integration": "vitest --project integration",
     "test:coverage": "vitest --coverage",
     "generate:management-api-types": "openapi-typescript https://api.supabase.com/api/v1-json -o ./src/management-api/types.ts"
   },

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -13,6 +13,7 @@
     "test": "vitest",
     "test:e2e": "vitest --project e2e",
     "test:unit": "vitest --project unit",
+    "test:coverage": "vitest --coverage",
     "generate:management-api-types": "openapi-typescript https://api.supabase.com/api/v1-json -o ./src/management-api/types.ts"
   },
   "files": [
@@ -42,6 +43,7 @@
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/common-tags": "^1.8.4",
     "@types/node": "^22.8.6",
+    "@vitest/coverage-v8": "^2.1.9",
     "ai": "^4.3.4",
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",

--- a/packages/mcp-server-supabase/src/index.test.ts
+++ b/packages/mcp-server-supabase/src/index.test.ts
@@ -1,0 +1,59 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamTransport } from '@supabase/mcp-utils';
+import { describe, expect, test } from 'vitest';
+import {
+  ACCESS_TOKEN,
+  API_URL,
+  MCP_CLIENT_NAME,
+  MCP_CLIENT_VERSION,
+} from '../test/mocks.js';
+import { createSupabaseMcpServer } from './index.js';
+
+type SetupOptions = {
+  accessToken?: string;
+  projectId?: string;
+  readOnly?: boolean;
+};
+
+async function setup(options: SetupOptions = {}) {
+  const { accessToken = ACCESS_TOKEN, projectId, readOnly } = options;
+  const clientTransport = new StreamTransport();
+  const serverTransport = new StreamTransport();
+
+  clientTransport.readable.pipeTo(serverTransport.writable);
+  serverTransport.readable.pipeTo(clientTransport.writable);
+
+  const client = new Client(
+    {
+      name: MCP_CLIENT_NAME,
+      version: MCP_CLIENT_VERSION,
+    },
+    {
+      capabilities: {},
+    }
+  );
+
+  const server = createSupabaseMcpServer({
+    platform: {
+      apiUrl: API_URL,
+      accessToken,
+    },
+    projectId,
+    readOnly,
+  });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, clientTransport, server, serverTransport };
+}
+
+describe('index', () => {
+  test('index.ts exports a working server', async () => {
+    const { client } = await setup();
+
+    const { tools } = await client.listTools();
+
+    expect(tools.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mcp-server-supabase/src/stdio.test.ts
+++ b/packages/mcp-server-supabase/src/stdio.test.ts
@@ -1,0 +1,77 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { describe, expect, test } from 'vitest';
+import {
+  ACCESS_TOKEN,
+  MCP_CLIENT_NAME,
+  MCP_CLIENT_VERSION,
+} from '../test/mocks.js';
+import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+
+type SetupOptions = {
+  accessToken?: string;
+  projectId?: string;
+  readOnly?: boolean;
+};
+
+async function setup(options: SetupOptions = {}) {
+  const { accessToken = ACCESS_TOKEN, projectId, readOnly } = options;
+
+  const client = new Client(
+    {
+      name: MCP_CLIENT_NAME,
+      version: MCP_CLIENT_VERSION,
+    },
+    {
+      capabilities: {},
+    }
+  );
+
+  client.setNotificationHandler(LoggingMessageNotificationSchema, (message) => {
+    const { level, data } = message.params;
+    if (level === 'error') {
+      console.error(data);
+    } else {
+      console.log(data);
+    }
+  });
+
+  const args = ['-y', '@supabase/mcp-server-supabase'];
+
+  if (accessToken) {
+    args.push('--access-token', accessToken);
+  }
+
+  if (projectId) {
+    args.push('--project-ref', projectId);
+  }
+
+  if (readOnly) {
+    args.push('--read-only');
+  }
+
+  const clientTransport = new StdioClientTransport({
+    command: 'npx',
+    args,
+  });
+
+  await client.connect(clientTransport);
+
+  return { client, clientTransport };
+}
+
+describe('stdio', () => {
+  test('server connects and lists tools', async () => {
+    const { client } = await setup();
+
+    const { tools } = await client.listTools();
+
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  test('missing access token fails', async () => {
+    const setupPromise = setup({ accessToken: null as any });
+
+    await expect(setupPromise).rejects.toThrow('MCP error -32000');
+  });
+});

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -4,7 +4,10 @@ import {
   type ManagementApiClient,
 } from '../management-api/index.js';
 import { listExtensionsSql, listTablesSql } from '../pg-meta/index.js';
-import type { PostgresExtension, PostgresTable } from '../pg-meta/types.js';
+import {
+  postgresExtensionSchema,
+  postgresTableSchema,
+} from '../pg-meta/types.js';
 import { injectableTool } from './util.js';
 
 export type DatabaseOperationToolsOptions = {
@@ -54,8 +57,9 @@ export function getDatabaseOperationTools({
       inject: { project_id },
       execute: async ({ project_id, schemas }) => {
         const sql = listTablesSql(schemas);
-        const data = await executeSql<PostgresTable>(project_id, sql);
-        return data;
+        const data = await executeSql(project_id, sql);
+        const tables = data.map((table) => postgresTableSchema.parse(table));
+        return tables;
       },
     }),
     list_extensions: injectableTool({
@@ -66,8 +70,11 @@ export function getDatabaseOperationTools({
       inject: { project_id },
       execute: async ({ project_id }) => {
         const sql = listExtensionsSql();
-        const data = await executeSql<PostgresExtension>(project_id, sql);
-        return data;
+        const data = await executeSql(project_id, sql);
+        const extensions = data.map((extension) =>
+          postgresExtensionSchema.parse(extension)
+        );
+        return extensions;
       },
     }),
     list_migrations: injectableTool({

--- a/packages/mcp-server-supabase/test/stdio.integration.ts
+++ b/packages/mcp-server-supabase/test/stdio.integration.ts
@@ -1,11 +1,7 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, test } from 'vitest';
-import {
-  ACCESS_TOKEN,
-  MCP_CLIENT_NAME,
-  MCP_CLIENT_VERSION,
-} from '../test/mocks.js';
+import { ACCESS_TOKEN, MCP_CLIENT_NAME, MCP_CLIENT_VERSION } from './mocks.js';
 import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 
 type SetupOptions = {
@@ -36,7 +32,8 @@ async function setup(options: SetupOptions = {}) {
     }
   });
 
-  const args = ['-y', '@supabase/mcp-server-supabase'];
+  const command = 'npx';
+  const args = ['@supabase/mcp-server-supabase'];
 
   if (accessToken) {
     args.push('--access-token', accessToken);
@@ -51,7 +48,7 @@ async function setup(options: SetupOptions = {}) {
   }
 
   const clientTransport = new StdioClientTransport({
-    command: 'npx',
+    command,
     args,
   });
 

--- a/packages/mcp-server-supabase/vitest.config.ts
+++ b/packages/mcp-server-supabase/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, configDefaults } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reporter: ['text', 'lcov'],
+      reportsDirectory: 'test/coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [...configDefaults.coverage.exclude!, 'src/stdio.ts'],
+    },
+  },
+});

--- a/packages/mcp-server-supabase/vitest.config.ts
+++ b/packages/mcp-server-supabase/vitest.config.ts
@@ -1,7 +1,25 @@
-import { defineConfig, configDefaults } from 'vitest/config';
+import { readFile } from 'fs/promises';
+import { Plugin } from 'vite';
+import { configDefaults, defineConfig } from 'vitest/config';
+
+function sqlLoaderPlugin(): Plugin {
+  return {
+    name: 'sql-loader',
+    async transform(code, id) {
+      if (id.endsWith('.sql')) {
+        const textContent = await readFile(id, 'utf8');
+        return `export default ${JSON.stringify(textContent)};`;
+      }
+      return code;
+    },
+  };
+}
 
 export default defineConfig({
+  plugins: [sqlLoaderPlugin()],
   test: {
+    setupFiles: ['./vitest.setup.ts'],
+    testTimeout: 30_000, // PGlite can take a while to initialize
     coverage: {
       reporter: ['text', 'lcov'],
       reportsDirectory: 'test/coverage',

--- a/packages/mcp-server-supabase/vitest.workspace.ts
+++ b/packages/mcp-server-supabase/vitest.workspace.ts
@@ -34,4 +34,11 @@ export default defineWorkspace([
       testTimeout: 60_000,
     },
   },
+  {
+    test: {
+      name: 'integration',
+      include: ['test/**/*.integration.ts'],
+      setupFiles: ['./vitest.setup.ts'],
+    },
+  },
 ]);

--- a/packages/mcp-server-supabase/vitest.workspace.ts
+++ b/packages/mcp-server-supabase/vitest.workspace.ts
@@ -1,44 +1,26 @@
-import { readFile } from 'fs/promises';
-import { Plugin } from 'vite';
 import { defineWorkspace } from 'vitest/config';
-
-function sqlLoaderPlugin(): Plugin {
-  return {
-    name: 'sql-loader',
-    async transform(code, id) {
-      if (id.endsWith('.sql')) {
-        const textContent = await readFile(id, 'utf8');
-        return `export default ${JSON.stringify(textContent)};`;
-      }
-      return code;
-    },
-  };
-}
 
 export default defineWorkspace([
   {
-    plugins: [sqlLoaderPlugin()],
+    extends: './vitest.config.ts',
     test: {
       name: 'unit',
       include: ['src/**/*.{test,spec}.ts'],
-      setupFiles: ['./vitest.setup.ts'],
-      testTimeout: 30_000, // PGlite can take a while to initialize
     },
   },
   {
-    plugins: [sqlLoaderPlugin()],
+    extends: './vitest.config.ts',
     test: {
       name: 'e2e',
       include: ['test/**/*.e2e.ts'],
-      setupFiles: ['./vitest.setup.ts'],
       testTimeout: 60_000,
     },
   },
   {
+    extends: './vitest.config.ts',
     test: {
       name: 'integration',
       include: ['test/**/*.integration.ts'],
-      setupFiles: ['./vitest.setup.ts'],
     },
   },
 ]);

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsup --clean",
     "test": "vitest",
+    "test:coverage": "vitest --coverage",
     "prepublishOnly": "npm run build"
   },
   "files": [


### PR DESCRIPTION
Reports test coverage via coveralls. Also adds an integration test for the stdio transport.

https://coveralls.io/github/supabase-community/supabase-mcp

[![Coverage Status](https://coveralls.io/repos/github/supabase-community/supabase-mcp/badge.svg?branch=chore/coveralls)](https://coveralls.io/github/supabase-community/supabase-mcp?branch=chore/coveralls)