### PR TITLE
fix: edge function path parsing on windows

### DIFF
--- a/packages/mcp-server-supabase/src/edge-function.ts
+++ b/packages/mcp-server-supabase/src/edge-function.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { fileURLToPath } from 'url';
+import { fileURLToPath } from 'node:url';
 import { extractFiles } from './eszip.js';
 import {
   assertSuccess,
@@ -84,11 +84,17 @@ export async function getFullEdgeFunction(
   const pathPrefix = getPathPrefix(deploymentId);
 
   const entrypoint_path = edgeFunction.entrypoint_path
-    ? fileURLToPath(edgeFunction.entrypoint_path).replace(pathPrefix, '')
+    ? fileURLToPath(edgeFunction.entrypoint_path, { windows: false }).replace(
+        pathPrefix,
+        ''
+      )
     : undefined;
 
   const import_map_path = edgeFunction.import_map_path
-    ? fileURLToPath(edgeFunction.import_map_path).replace(pathPrefix, '')
+    ? fileURLToPath(edgeFunction.import_map_path, { windows: false }).replace(
+        pathPrefix,
+        ''
+      )
     : undefined;
 
   const eszipResponse = await managementApiClient.GET(

--- a/packages/mcp-server-supabase/src/eszip.ts
+++ b/packages/mcp-server-supabase/src/eszip.ts
@@ -1,5 +1,5 @@
 import { build, Parser } from '@deno/eszip';
-import { join, relative } from 'node:path';
+import { join, relative } from 'node:path/posix';
 import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 
@@ -45,7 +45,10 @@ export async function extractFiles(
       const sourceMapString: string =
         await parser.getModuleSourceMap(specifier);
 
-      const filePath = relative(pathPrefix, fileURLToPath(specifier));
+      const filePath = relative(
+        pathPrefix,
+        fileURLToPath(specifier, { windows: false })
+      );
 
       const file = new File([source], filePath, {
         type: 'text/plain',

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -2,7 +2,7 @@ import { PGlite, type PGliteInterface } from '@electric-sql/pglite';
 import { format } from 'date-fns';
 import { http, HttpResponse } from 'msw';
 import { customAlphabet } from 'nanoid';
-import { join } from 'node:path';
+import { join } from 'node:path/posix';
 import { expect } from 'vitest';
 import { z } from 'zod';
 import packageJson from '../package.json' with { type: 'json' };


### PR DESCRIPTION
We use some Node.js path parsing functions like `fileURLToPath()`, `join()`, and `relative()` when extracting edge function files from eszip archives and normalizing paths for the LLM. Our edge function's paths (like `entrypoint_path` and `import_map_path`) are always in posix format, but the above functions will change behaviour based on the current running OS. This means that if you run the MCP server on Windows, it will fail to parse the above paths correctly.

This PR fixes this to opt out of Windows path parsing and explicitly use posix paths.

Fixes #66 