### PR TITLE
fix: apply migration result

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -667,7 +667,7 @@ describe('tools', () => {
       },
     });
 
-    expect(result).toEqual(undefined);
+    expect(result).toEqual({ success: true });
 
     const listMigrationsResult = await callTool({
       name: 'list_migrations',

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -88,6 +88,8 @@ export function getDatabaseOperationTools({
           name,
           query,
         });
+
+        return { success: true };
       },
     }),
     execute_sql: injectableTool({


### PR DESCRIPTION
Fixes `apply_migration` by giving it a result of `{ success: true }`. We recently removed the query result from `apply_migration` for security reasons, but it appears MCP clients need _some_ result, so this is the compromise.