### PR TITLE
feat: allow enabling of specific feature groups + adds storage tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ _**Note:** these tools will be unavailable if the server is [scoped to a project
 - `execute_sql`: Executes raw SQL in the database. LLMs should use this for regular queries that don't change the schema.
 - `get_logs`: Gets logs for a Supabase project by service type (api, postgres, edge functions, auth, storage, realtime). LLMs can use this to help with debugging and monitoring service performance.
 
+#### Storage Operations
+
+- `list_storage_buckets`: Lists all storage buckets in a Supabase project.
+- `get_storage_config`: Gets the storage config for a Supabase project.
+- `update_storage_config`: Updates the storage config for a Supabase project (requires a paid plan).
+
 #### Edge Function Management
 
 - `list_edge_functions`: Lists all Edge Functions in a Supabase project.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ The following additional options are available:
 
 - `--project-ref`: Used to scope the server to a specific project. See [project scoped mode](#project-scoped-mode).
 - `--read-only`: Used to restrict the server to read-only queries. See [read-only mode](#read-only-mode).
+- `--features`: Used to specify which feature groups to enable. Available features are: 'account', 'branching', 'database', 'debug', 'development', 'docs', 'functions', and 'storage'. Multiple features can be specified with comma separation (e.g., `--features=database,debug,docs`). 
+  - When no project is specified: Defaults to ['account', 'database', 'debug', 'docs', 'functions']
+  - When a project is specified: Defaults to ['database', 'debug', 'docs', 'functions']
 
 If you are on Windows, you will need to [prefix the command](#windows). If your MCP client doesn't accept JSON, the direct CLI command is:
 

--- a/packages/mcp-server-supabase/src/index.test.ts
+++ b/packages/mcp-server-supabase/src/index.test.ts
@@ -13,10 +13,11 @@ type SetupOptions = {
   accessToken?: string;
   projectId?: string;
   readOnly?: boolean;
+  features?: string[];
 };
 
 async function setup(options: SetupOptions = {}) {
-  const { accessToken = ACCESS_TOKEN, projectId, readOnly } = options;
+  const { accessToken = ACCESS_TOKEN, projectId, readOnly, features } = options;
   const clientTransport = new StreamTransport();
   const serverTransport = new StreamTransport();
 
@@ -40,6 +41,7 @@ async function setup(options: SetupOptions = {}) {
     },
     projectId,
     readOnly,
+    features,
   });
 
   await server.connect(serverTransport);

--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -30,6 +30,7 @@ import {
   type GetLogsOptions,
   type ResetBranchOptions,
   type SupabasePlatform,
+  type StorageConfigUpdate,
 } from './index.js';
 
 const { version } = packageJson;
@@ -599,6 +600,69 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to rebase branch');
+    },
+
+    // Storage methods
+    async listAllBuckets(project_id: string) {
+      const response = await managementApiClient.GET(
+        '/v1/projects/{ref}/storage/buckets',
+        {
+          params: {
+            path: {
+              ref: project_id,
+            },
+          },
+        }
+      );
+
+      assertSuccess(response, 'Failed to list storage buckets');
+
+      return response.data;
+    },
+
+    async getStorageConfig(project_id: string) {
+      const response = await managementApiClient.GET(
+        '/v1/projects/{ref}/config/storage',
+        {
+          params: {
+            path: {
+              ref: project_id,
+            },
+          },
+        }
+      );
+
+      assertSuccess(response, 'Failed to get storage config');
+
+      return response.data;
+    },
+
+    async updateStorageConfig(projectId: string, config: StorageConfigUpdate) {
+      const response = await managementApiClient.PATCH(
+        '/v1/projects/{ref}/config/storage',
+        {
+          params: {
+            path: {
+              ref: projectId,
+            },
+          },
+          body: {
+            fileSizeLimit: config.fileSizeLimit,
+            features: {
+              imageTransformation: {
+                enabled: config.features.imageTransformation.enabled,
+              },
+              s3Protocol: {
+                enabled: config.features.s3Protocol.enabled,
+              },
+            },
+          },
+        }
+      );
+
+      assertSuccess(response, 'Failed to update storage config');
+
+      return response.data;
     },
   };
 

--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -29,8 +29,8 @@ import {
   type ExecuteSqlOptions,
   type GetLogsOptions,
   type ResetBranchOptions,
+  type StorageConfig,
   type SupabasePlatform,
-  type StorageConfigUpdate,
 } from './index.js';
 
 const { version } = packageJson;
@@ -637,7 +637,7 @@ export function createSupabaseApiPlatform(
       return response.data;
     },
 
-    async updateStorageConfig(projectId: string, config: StorageConfigUpdate) {
+    async updateStorageConfig(projectId: string, config: StorageConfig) {
       const response = await managementApiClient.PATCH(
         '/v1/projects/{ref}/config/storage',
         {

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -154,7 +154,9 @@ export type GenerateTypescriptTypesResult = z.infer<
 
 export type StorageConfigResponse = z.infer<typeof storageConfigResponseSchema>;
 export type StorageConfigUpdate = z.infer<typeof storageConfigResponseSchema>;
-export type StorageBucketResponse = z.infer<typeof v1StorageBucketResponseSchema>;
+export type StorageBucketResponse = z.infer<
+  typeof v1StorageBucketResponseSchema
+>;
 
 export type SupabasePlatform = {
   init?(info: InitData): Promise<void>;
@@ -212,6 +214,9 @@ export type SupabasePlatform = {
 
   // Storage
   getStorageConfig(projectId: string): Promise<StorageConfigResponse>;
-  updateStorageConfig(projectId: string, config: StorageConfigUpdate): Promise<void>;
+  updateStorageConfig(
+    projectId: string,
+    config: StorageConfigUpdate
+  ): Promise<void>;
   listAllBuckets(projectId: string): Promise<StorageBucketResponse[]>;
 };

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -2,6 +2,23 @@ import { z } from 'zod';
 import { AWS_REGION_CODES } from '../regions.js';
 import type { InitData } from '@supabase/mcp-utils';
 
+export const v1StorageBucketResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  owner: z.string(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  public: z.boolean(),
+});
+
+export const storageConfigResponseSchema = z.object({
+  fileSizeLimit: z.number(),
+  features: z.object({
+    imageTransformation: z.object({ enabled: z.boolean() }),
+    s3Protocol: z.object({ enabled: z.boolean() }),
+  }),
+});
+
 export const organizationSchema = z.object({
   id: z.string(),
   name: z.string(),
@@ -135,6 +152,10 @@ export type GenerateTypescriptTypesResult = z.infer<
   typeof generateTypescriptTypesResultSchema
 >;
 
+export type StorageConfigResponse = z.infer<typeof storageConfigResponseSchema>;
+export type StorageConfigUpdate = z.infer<typeof storageConfigResponseSchema>;
+export type StorageBucketResponse = z.infer<typeof v1StorageBucketResponseSchema>;
+
 export type SupabasePlatform = {
   init?(info: InitData): Promise<void>;
 
@@ -186,4 +207,9 @@ export type SupabasePlatform = {
   mergeBranch(branchId: string): Promise<void>;
   resetBranch(branchId: string, options: ResetBranchOptions): Promise<void>;
   rebaseBranch(branchId: string): Promise<void>;
+
+  // Storage
+  getStorageConfig(projectId: string): Promise<StorageConfigResponse>;
+  updateStorageConfig(projectId: string, config: StorageConfigUpdate): Promise<void>;
+  listAllBuckets(projectId: string): Promise<StorageBucketResponse[]>;
 };

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -1,6 +1,6 @@
+import type { InitData } from '@supabase/mcp-utils';
 import { z } from 'zod';
 import { AWS_REGION_CODES } from '../regions.js';
-import type { InitData } from '@supabase/mcp-utils';
 
 export const v1StorageBucketResponseSchema = z.object({
   id: z.string(),
@@ -169,7 +169,7 @@ export type SupabasePlatform = {
     options: ApplyMigrationOptions
   ): Promise<void>;
 
-  // Project management
+  // Account
   listOrganizations(): Promise<Pick<Organization, 'id' | 'name'>[]>;
   getOrganization(organizationId: string): Promise<Organization>;
   listProjects(): Promise<Project[]>;

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -2,7 +2,7 @@ import type { InitData } from '@supabase/mcp-utils';
 import { z } from 'zod';
 import { AWS_REGION_CODES } from '../regions.js';
 
-export const v1StorageBucketResponseSchema = z.object({
+export const storageBucketSchema = z.object({
   id: z.string(),
   name: z.string(),
   owner: z.string(),
@@ -11,7 +11,7 @@ export const v1StorageBucketResponseSchema = z.object({
   public: z.boolean(),
 });
 
-export const storageConfigResponseSchema = z.object({
+export const storageConfigSchema = z.object({
   fileSizeLimit: z.number(),
   features: z.object({
     imageTransformation: z.object({ enabled: z.boolean() }),
@@ -152,11 +152,8 @@ export type GenerateTypescriptTypesResult = z.infer<
   typeof generateTypescriptTypesResultSchema
 >;
 
-export type StorageConfigResponse = z.infer<typeof storageConfigResponseSchema>;
-export type StorageConfigUpdate = z.infer<typeof storageConfigResponseSchema>;
-export type StorageBucketResponse = z.infer<
-  typeof v1StorageBucketResponseSchema
->;
+export type StorageConfig = z.infer<typeof storageConfigSchema>;
+export type StorageBucket = z.infer<typeof storageBucketSchema>;
 
 export type SupabasePlatform = {
   init?(info: InitData): Promise<void>;
@@ -213,10 +210,7 @@ export type SupabasePlatform = {
   rebaseBranch(branchId: string): Promise<void>;
 
   // Storage
-  getStorageConfig(projectId: string): Promise<StorageConfigResponse>;
-  updateStorageConfig(
-    projectId: string,
-    config: StorageConfigUpdate
-  ): Promise<void>;
-  listAllBuckets(projectId: string): Promise<StorageBucketResponse[]>;
+  getStorageConfig(projectId: string): Promise<StorageConfig>;
+  updateStorageConfig(projectId: string, config: StorageConfig): Promise<void>;
+  listAllBuckets(projectId: string): Promise<StorageBucket[]>;
 };

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -654,8 +654,7 @@ describe('tools', () => {
       },
     });
 
-    // Update should succeed without error
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ success: true });
   });
 
   test('execute sql', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -570,18 +570,22 @@ describe('tools', () => {
 
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBe(2);
-    expect(result[0]).toEqual(expect.objectContaining({
-      name: 'bucket1',
-      public: true,
-      created_at: expect.any(String),
-      updated_at: expect.any(String),
-    }));
-    expect(result[1]).toEqual(expect.objectContaining({
-      name: 'bucket2',
-      public: false,
-      created_at: expect.any(String),
-      updated_at: expect.any(String),
-    }));
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        name: 'bucket1',
+        public: true,
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    );
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        name: 'bucket2',
+        public: false,
+        created_at: expect.any(String),
+        updated_at: expect.any(String),
+      })
+    );
   });
 
   test('get storage config', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -39,13 +39,14 @@ type SetupOptions = {
   accessToken?: string;
   projectId?: string;
   readOnly?: boolean;
+  features?: string[];
 };
 
 /**
  * Sets up an MCP client and server for testing.
  */
 async function setup(options: SetupOptions = {}) {
-  const { accessToken = ACCESS_TOKEN, projectId, readOnly } = options;
+  const { accessToken = ACCESS_TOKEN, projectId, readOnly, features } = options;
   const clientTransport = new StreamTransport();
   const serverTransport = new StreamTransport();
 
@@ -71,6 +72,7 @@ async function setup(options: SetupOptions = {}) {
     platform,
     projectId,
     readOnly,
+    features,
   });
 
   await server.connect(serverTransport);
@@ -495,7 +497,7 @@ describe('tools', () => {
   });
 
   test('get project url', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['development'] });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -520,7 +522,7 @@ describe('tools', () => {
   });
 
   test('get anon key', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['development'] });
     const org = await createOrganization({
       name: 'My Org',
       plan: 'free',
@@ -543,7 +545,7 @@ describe('tools', () => {
   });
 
   test('list storage buckets', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['storage'] });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -589,7 +591,7 @@ describe('tools', () => {
   });
 
   test('get storage config', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['storage'] });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -621,7 +623,7 @@ describe('tools', () => {
   });
 
   test('update storage config', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['storage'] });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1559,7 +1561,9 @@ describe('tools', () => {
   });
 
   test('create branch', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({
+      features: ['account', 'branching', 'database'],
+    });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1611,7 +1615,7 @@ describe('tools', () => {
   });
 
   test('create branch without cost confirmation fails', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['branching'] });
 
     const org = await createOrganization({
       name: 'Paid Org',
@@ -1641,7 +1645,9 @@ describe('tools', () => {
   });
 
   test('delete branch', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({
+      features: ['account', 'branching', 'database'],
+    });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1720,7 +1726,7 @@ describe('tools', () => {
   });
 
   test('list branches', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({ features: ['branching'] });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1746,7 +1752,9 @@ describe('tools', () => {
   });
 
   test('merge branch', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({
+      features: ['account', 'branching', 'database'],
+    });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1813,7 +1821,9 @@ describe('tools', () => {
   });
 
   test('reset branch', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({
+      features: ['account', 'branching', 'database'],
+    });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1889,7 +1899,9 @@ describe('tools', () => {
   });
 
   test('revert migrations', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({
+      features: ['account', 'branching', 'database'],
+    });
 
     const org = await createOrganization({
       name: 'My Org',
@@ -1989,7 +2001,9 @@ describe('tools', () => {
   });
 
   test('rebase branch', async () => {
-    const { callTool } = await setup();
+    const { callTool } = await setup({
+      features: ['account', 'branching', 'database'],
+    });
 
     const org = await createOrganization({
       name: 'My Org',

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -7,6 +7,7 @@ import { getDebuggingTools } from './tools/debugging-tools.js';
 import { getDevelopmentTools } from './tools/development-tools.js';
 import { getEdgeFunctionTools } from './tools/edge-function-tools.js';
 import { getProjectManagementTools } from './tools/project-management-tools.js';
+import { getStorageTools } from './tools/storage-tools.js';
 
 const { version } = packageJson;
 
@@ -57,7 +58,8 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         getEdgeFunctionTools({ platform, projectId }),
         getDebuggingTools({ platform, projectId }),
         getDevelopmentTools({ platform, projectId }),
-        getBranchingTools({ platform, projectId })
+        getBranchingTools({ platform, projectId }),
+        getStorageTools({ platform, projectId })
       );
 
       return tools;

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -8,7 +8,7 @@ import { getDebuggingTools } from './tools/debugging-tools.js';
 import { getDevelopmentTools } from './tools/development-tools.js';
 import { getDocsTools } from './tools/docs-tools.js';
 import { getEdgeFunctionTools } from './tools/edge-function-tools.js';
-import { getProjectManagementTools } from './tools/project-management-tools.js';
+import { getAccountTools } from './tools/account-tools.js';
 import { getStorageTools } from './tools/storage-tools.js';
 
 const { version } = packageJson;

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -54,7 +54,7 @@ export type SupabaseMcpServerOptions = {
    * Features to enable.
    * Options: 'account', 'branching', 'database', 'debug', 'development', 'docs', 'functions', 'storage'
    */
-  features?: FeatureGroup[];
+  features?: string[];
 };
 
 const featureGroupSchema = z.enum([

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -56,7 +56,15 @@ export type SupabaseMcpServerOptions = {
   features?: string[];
 };
 
-export type FeatureGroup = 'account' | 'branching' | 'database' | 'debug' | 'development' | 'docs' | 'functions' | 'storage';
+export type FeatureGroup =
+  | 'account'
+  | 'branching'
+  | 'database'
+  | 'debug'
+  | 'development'
+  | 'docs'
+  | 'functions'
+  | 'storage';
 
 // Single source of truth for valid feature values
 export const VALID_FEATURES: readonly FeatureGroup[] = [
@@ -67,11 +75,22 @@ export const VALID_FEATURES: readonly FeatureGroup[] = [
   'development',
   'docs',
   'functions',
-  'storage'
+  'storage',
 ] as const;
 
-const DEFAULT_ACCOUNT_FEATURES: FeatureGroup[] = ['account', 'database', 'debug', 'docs', 'functions'];
-const DEFAULT_PROJECT_FEATURES: FeatureGroup[] = ['database', 'debug', 'docs', 'functions'];
+const DEFAULT_ACCOUNT_FEATURES: FeatureGroup[] = [
+  'account',
+  'database',
+  'debug',
+  'docs',
+  'functions',
+];
+const DEFAULT_PROJECT_FEATURES: FeatureGroup[] = [
+  'database',
+  'debug',
+  'docs',
+  'functions',
+];
 
 /**
  * Creates an MCP server for interacting with Supabase.
@@ -91,15 +110,17 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
 
   if (features && features.length > 0) {
     // Use explicitly provided features
-    features.forEach(feature => {
+    features.forEach((feature) => {
       if (VALID_FEATURES.includes(feature as FeatureGroup)) {
         enabledFeatures.add(feature as FeatureGroup);
       }
     });
   } else {
     // Use defaults based on mode
-    const defaultFeatures = projectId ? DEFAULT_PROJECT_FEATURES : DEFAULT_ACCOUNT_FEATURES;
-    defaultFeatures.forEach(feature => enabledFeatures.add(feature));
+    const defaultFeatures = projectId
+      ? DEFAULT_PROJECT_FEATURES
+      : DEFAULT_ACCOUNT_FEATURES;
+    defaultFeatures.forEach((feature) => enabledFeatures.add(feature));
   }
 
   const server = createMcpServer({
@@ -124,7 +145,10 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       }
 
       if (enabledFeatures.has('database')) {
-        Object.assign(tools, getDatabaseOperationTools({ platform, projectId, readOnly }));
+        Object.assign(
+          tools,
+          getDatabaseOperationTools({ platform, projectId, readOnly })
+        );
       }
 
       if (enabledFeatures.has('debug')) {

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -9,9 +9,7 @@ export type AccountToolsOptions = {
   platform: SupabasePlatform;
 };
 
-export function getAccountTools({
-  platform,
-}: AccountToolsOptions) {
+export function getAccountTools({ platform }: AccountToolsOptions) {
   return {
     list_organizations: tool({
       description: 'Lists all organizations that the user is a member of.',

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -5,13 +5,13 @@ import { type Cost, getBranchCost, getNextProjectCost } from '../pricing.js';
 import { AWS_REGION_CODES } from '../regions.js';
 import { hashObject } from '../util.js';
 
-export type ProjectManagementToolsOptions = {
+export type AccountToolsOptions = {
   platform: SupabasePlatform;
 };
 
-export function getProjectManagementTools({
+export function getAccountTools({
   platform,
-}: ProjectManagementToolsOptions) {
+}: AccountToolsOptions) {
   return {
     list_organizations: tool({
       description: 'Lists all organizations that the user is a member of.',

--- a/packages/mcp-server-supabase/src/tools/storage-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/storage-tools.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import type { SupabasePlatform } from '../platform/types.js';
+import { injectableTool } from './util.js';
+
+export type StorageToolsOptions = {
+  platform: SupabasePlatform;
+  projectId?: string;
+};
+
+export function getStorageTools({
+  platform,
+  projectId,
+}: StorageToolsOptions) {
+  const project_id = projectId;
+
+  return {
+    list_storage_buckets: injectableTool({
+      description: 'Lists all storage buckets in a Supabase project.',
+      parameters: z.object({
+        project_id: z.string(),
+      }),
+      inject: { project_id },
+      execute: async ({ project_id }) => {
+        return await platform.listAllBuckets(project_id);
+      },
+    }),
+    get_storage_config: injectableTool({
+      description: 'Get the storage config for a Supabase project.',
+      parameters: z.object({
+        project_id: z.string(),
+      }),
+      inject: { project_id },
+      execute: async ({ project_id }) => {
+        return await platform.getStorageConfig(project_id);
+      },
+    }),
+    update_storage_config: injectableTool({
+      description: 'Update the storage config for a Supabase project.',
+      parameters: z.object({
+        project_id: z.string(),
+        config: z.object({
+          fileSizeLimit: z.number(),
+          features: z.object({
+            imageTransformation: z.object({ enabled: z.boolean() }),
+            s3Protocol: z.object({ enabled: z.boolean() }),
+          }),
+        })
+      }),
+      inject: { project_id },
+      execute: async ({ project_id, config }) => {
+        return await platform.updateStorageConfig(project_id, config);
+      },
+    }),
+  };
+}

--- a/packages/mcp-server-supabase/src/tools/storage-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/storage-tools.ts
@@ -7,10 +7,7 @@ export type StorageToolsOptions = {
   projectId?: string;
 };
 
-export function getStorageTools({
-  platform,
-  projectId,
-}: StorageToolsOptions) {
+export function getStorageTools({ platform, projectId }: StorageToolsOptions) {
   const project_id = projectId;
 
   return {
@@ -44,7 +41,7 @@ export function getStorageTools({
             imageTransformation: z.object({ enabled: z.boolean() }),
             s3Protocol: z.object({ enabled: z.boolean() }),
           }),
-        })
+        }),
       }),
       inject: { project_id },
       execute: async ({ project_id, config }) => {

--- a/packages/mcp-server-supabase/src/tools/storage-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/storage-tools.ts
@@ -45,7 +45,8 @@ export function getStorageTools({ platform, projectId }: StorageToolsOptions) {
       }),
       inject: { project_id },
       execute: async ({ project_id, config }) => {
-        return await platform.updateStorageConfig(project_id, config);
+        await platform.updateStorageConfig(project_id, config);
+        return { success: true };
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -16,6 +16,7 @@ async function main() {
       ['read-only']: readOnly,
       ['api-url']: apiUrl,
       ['version']: showVersion,
+      ['features']: features,
     },
   } = parseArgs({
     options: {
@@ -35,6 +36,9 @@ async function main() {
       ['version']: {
         type: 'boolean',
       },
+      ['features']: {
+        type: 'string',
+      },
     },
   });
 
@@ -45,6 +49,8 @@ async function main() {
 
   // Use access token from CLI argument or environment variable
   const accessToken = cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
+
+  const featureList = features?.split(',') ?? [];
 
   if (!accessToken) {
     console.error(
@@ -62,6 +68,7 @@ async function main() {
     platform,
     projectId,
     readOnly,
+    features: featureList,
   });
 
   const transport = new StdioServerTransport();

--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -5,6 +5,7 @@ import { parseArgs } from 'node:util';
 import packageJson from '../../package.json' with { type: 'json' };
 import { createSupabaseApiPlatform } from '../platform/api-platform.js';
 import { createSupabaseMcpServer } from '../server.js';
+import { parseList } from './util.js';
 
 const { version } = packageJson;
 
@@ -16,7 +17,7 @@ async function main() {
       ['read-only']: readOnly,
       ['api-url']: apiUrl,
       ['version']: showVersion,
-      ['features']: features,
+      ['features']: cliFeatures,
     },
   } = parseArgs({
     options: {
@@ -47,10 +48,7 @@ async function main() {
     process.exit(0);
   }
 
-  // Use access token from CLI argument or environment variable
   const accessToken = cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
-
-  const featureList = features?.split(',') ?? [];
 
   if (!accessToken) {
     console.error(
@@ -58,6 +56,8 @@ async function main() {
     );
     process.exit(1);
   }
+
+  const features = cliFeatures ? parseList(cliFeatures) : undefined;
 
   const platform = createSupabaseApiPlatform({
     accessToken,
@@ -68,7 +68,7 @@ async function main() {
     platform,
     projectId,
     readOnly,
-    features: featureList,
+    features,
   });
 
   const transport = new StdioServerTransport();

--- a/packages/mcp-server-supabase/src/transports/util.test.ts
+++ b/packages/mcp-server-supabase/src/transports/util.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { parseList } from './util.js';
+
+describe('parseList', () => {
+  test('should parse comma-delimited list', () => {
+    const result = parseList('item1,item2,item3');
+    expect(result).toEqual(['item1', 'item2', 'item3']);
+  });
+
+  test('should handle spaces around items', () => {
+    const result = parseList('item1, item2 , item3');
+    expect(result).toEqual(['item1', 'item2', 'item3']);
+  });
+
+  test('should filter out empty items', () => {
+    const result = parseList('item1,,item2,');
+    expect(result).toEqual(['item1', 'item2']);
+  });
+
+  test('should handle custom delimiter', () => {
+    const result = parseList('item1|item2|item3', '|');
+    expect(result).toEqual(['item1', 'item2', 'item3']);
+  });
+
+  test('should handle single item', () => {
+    const result = parseList('item1');
+    expect(result).toEqual(['item1']);
+  });
+
+  test('should handle empty string', () => {
+    const result = parseList('');
+    expect(result).toEqual([]);
+  });
+
+  test('should handle string with only delimiters', () => {
+    const result = parseList(',,,');
+    expect(result).toEqual([]);
+  });
+
+  test('should handle semicolon delimiter', () => {
+    const result = parseList('item1; item2; item3', ';');
+    expect(result).toEqual(['item1', 'item2', 'item3']);
+  });
+});

--- a/packages/mcp-server-supabase/src/transports/util.ts
+++ b/packages/mcp-server-supabase/src/transports/util.ts
@@ -1,0 +1,10 @@
+/**
+ * Parses a delimited list of items into an array,
+ * trimming whitespace and filtering out empty items.
+ *
+ * Default delimiter is a comma (`,`).
+ */
+export function parseList(list: string, delimiter = ','): string[] {
+  const items = list.split(delimiter).map((feature) => feature.trim());
+  return items.filter((feature) => feature !== '');
+}

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -806,18 +806,20 @@ export const mockManagementApi = [
         );
       }
 
-      const buckets = Array.from(project.storage_buckets.values()).map(bucket => ({
-        id: bucket.id,
-        name: bucket.name,
-        public: bucket.public,
-        created_at: bucket.created_at.toISOString(),
-        updated_at: bucket.updated_at.toISOString(),
-      }));
+      const buckets = Array.from(project.storage_buckets.values()).map(
+        (bucket) => ({
+          id: bucket.id,
+          name: bucket.name,
+          public: bucket.public,
+          created_at: bucket.created_at.toISOString(),
+          updated_at: bucket.updated_at.toISOString(),
+        })
+      );
 
       return HttpResponse.json(buckets);
     }
   ),
-  
+
   /**
    * Get storage config
    */
@@ -837,11 +839,11 @@ export const mockManagementApi = [
         features: {
           imageTransformation: { enabled: true },
           s3Protocol: { enabled: false },
-        }
+        },
       });
     }
   ),
-  
+
   /**
    * Update storage config
    */
@@ -867,7 +869,7 @@ export const mockManagementApi = [
         );
       }
     }
-  )
+  ),
 ];
 
 export async function createOrganization(options: MockOrganizationOptions) {
@@ -1177,7 +1179,10 @@ export class MockProject {
     }
   }
 
-  createStorageBucket(name: string, isPublic: boolean = false): MockStorageBucket {
+  createStorageBucket(
+    name: string,
+    isPublic: boolean = false
+  ): MockStorageBucket {
     const id = nanoid();
     const bucket: MockStorageBucket = {
       id,


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduces feature groups that can be enabled or disabled when needed. In addition to `project-ref` and `read-only,` a new config option called `features` is added.

`--features`: Used to specify which feature groups to enable. Available features are: 'account', 'branching', 'database', 'debug', 'development', 'docs', 'functions', and 'storage'. Multiple features can be specified with comma separation (e.g., `--features=database,debug,docs`). 
  - When no project is specified: Defaults to ['account', 'database', 'debug', 'docs', 'functions']
  - When a project is specified: Defaults to ['database', 'debug', 'docs', 'functions']

## What is the current behavior?

Currently, all features are enabled by default. To better manage tool limits, this change allows users to enable only the feature groups they require, thus reducing the number of unnecessary active tools in the MCP server.

Based on [this idea](https://github.com/supabase-community/supabase-mcp/issues/52#issuecomment-2802200789) and [this discussion](https://github.com/supabase-community/supabase-mcp/pull/89).

