### PR TITLE
feat: re-enable branching tools by default

### DIFF
--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -77,6 +77,7 @@ const DEFAULT_FEATURES: FeatureGroup[] = [
   'debug',
   'development',
   'functions',
+  'branching',
 ];
 
 /**


### PR DESCRIPTION
Re-enables branching as a default feature so that we don't break existing setups. Note each tool group can now be manually enabled/disabled via the `--features` option: #98 