### PR TITLE
Conditional tools based on platform implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ You can enable or disable specific tool groups by passing the `--features` flag 
 npx -y @supabase/mcp-server-supabase@latest --features=database,docs
 ```
 
-Available groups are: [`account`](#account), [`docs`](#knowledge-base), [`database`](#database), [`debug`](#debug), [`development`](#development), [`functions`](#edge-functions), [`storage`](#storage), and [`branching`](#branching-experimental-requires-a-paid-plan).
+Available groups are: [`account`](#account), [`docs`](#knowledge-base), [`database`](#database), [`debugging`](#debugging), [`development`](#development), [`functions`](#edge-functions), [`storage`](#storage), and [`branching`](#branching-experimental-requires-a-paid-plan).
 
-If this flag is not passed, the default feature groups are: `account`, `database`, `debug`, `development`, `docs`, `functions`, and `branching`.
+If this flag is not passed, the default feature groups are: `account`, `database`, `debugging`, `development`, `docs`, `functions`, and `branching`.
 
 ## Tools
 
@@ -198,9 +198,9 @@ Enabled by default. Use `database` to target this group of tools with the [`--fe
 - `apply_migration`: Applies a SQL migration to the database. SQL passed to this tool will be tracked within the database, so LLMs should use this for DDL operations (schema changes).
 - `execute_sql`: Executes raw SQL in the database. LLMs should use this for regular queries that don't change the schema.
 
-#### Debug
+#### Debugging
 
-Enabled by default. Use `debug` to target this group of tools with the [`--features`](#feature-groups) option.
+Enabled by default. Use `debugging` to target this group of tools with the [`--features`](#feature-groups) option.
 
 - `get_logs`: Gets logs for a Supabase project by service type (api, postgres, edge functions, auth, storage, realtime). LLMs can use this to help with debugging and monitoring service performance.
 - `get_advisors`: Gets a list of advisory notices for a Supabase project. LLMs can use this to check for security vulnerabilities or performance issues.

--- a/packages/mcp-server-supabase/src/index.test.ts
+++ b/packages/mcp-server-supabase/src/index.test.ts
@@ -7,7 +7,7 @@ import {
   MCP_CLIENT_NAME,
   MCP_CLIENT_VERSION,
 } from '../test/mocks.js';
-import { createSupabaseMcpServer } from './index.js';
+import { createSupabaseApiPlatform, createSupabaseMcpServer } from './index.js';
 
 type SetupOptions = {
   accessToken?: string;
@@ -34,11 +34,13 @@ async function setup(options: SetupOptions = {}) {
     }
   );
 
+  const platform = createSupabaseApiPlatform({
+    apiUrl: API_URL,
+    accessToken,
+  });
+
   const server = createSupabaseMcpServer({
-    platform: {
-      apiUrl: API_URL,
-      accessToken,
-    },
+    platform,
     projectId,
     readOnly,
     features,

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -155,18 +155,16 @@ export type GenerateTypescriptTypesResult = z.infer<
 export type StorageConfig = z.infer<typeof storageConfigSchema>;
 export type StorageBucket = z.infer<typeof storageBucketSchema>;
 
-export type SupabasePlatform = {
-  init?(info: InitData): Promise<void>;
-
-  // Database operations
+export type DatabaseOperations = {
   executeSql<T>(projectId: string, options: ExecuteSqlOptions): Promise<T[]>;
   listMigrations(projectId: string): Promise<Migration[]>;
   applyMigration(
     projectId: string,
     options: ApplyMigrationOptions
   ): Promise<void>;
+};
 
-  // Account
+export type AccountOperations = {
   listOrganizations(): Promise<Pick<Organization, 'id' | 'name'>[]>;
   getOrganization(organizationId: string): Promise<Organization>;
   listProjects(): Promise<Project[]>;
@@ -174,8 +172,9 @@ export type SupabasePlatform = {
   createProject(options: CreateProjectOptions): Promise<Project>;
   pauseProject(projectId: string): Promise<void>;
   restoreProject(projectId: string): Promise<void>;
+};
 
-  // Edge functions
+export type EdgeFunctionsOperations = {
   listEdgeFunctions(projectId: string): Promise<EdgeFunction[]>;
   getEdgeFunction(
     projectId: string,
@@ -185,20 +184,29 @@ export type SupabasePlatform = {
     projectId: string,
     options: DeployEdgeFunctionOptions
   ): Promise<Omit<EdgeFunction, 'files'>>;
+};
 
-  // Debugging
+export type DebuggingOperations = {
   getLogs(projectId: string, options: GetLogsOptions): Promise<unknown>;
   getSecurityAdvisors(projectId: string): Promise<unknown>;
   getPerformanceAdvisors(projectId: string): Promise<unknown>;
+};
 
-  // Development
+export type DevelopmentOperations = {
   getProjectUrl(projectId: string): Promise<string>;
   getAnonKey(projectId: string): Promise<string>;
   generateTypescriptTypes(
     projectId: string
   ): Promise<GenerateTypescriptTypesResult>;
+};
 
-  // Branching
+export type StorageOperations = {
+  getStorageConfig(projectId: string): Promise<StorageConfig>;
+  updateStorageConfig(projectId: string, config: StorageConfig): Promise<void>;
+  listAllBuckets(projectId: string): Promise<StorageBucket[]>;
+};
+
+export type BranchingOperations = {
   listBranches(projectId: string): Promise<Branch[]>;
   createBranch(
     projectId: string,
@@ -208,9 +216,15 @@ export type SupabasePlatform = {
   mergeBranch(branchId: string): Promise<void>;
   resetBranch(branchId: string, options: ResetBranchOptions): Promise<void>;
   rebaseBranch(branchId: string): Promise<void>;
+};
 
-  // Storage
-  getStorageConfig(projectId: string): Promise<StorageConfig>;
-  updateStorageConfig(projectId: string, config: StorageConfig): Promise<void>;
-  listAllBuckets(projectId: string): Promise<StorageBucket[]>;
+export type SupabasePlatform = {
+  init?(info: InitData): Promise<void>;
+  account?: AccountOperations;
+  database?: DatabaseOperations;
+  functions?: EdgeFunctionsOperations;
+  debugging?: DebuggingOperations;
+  development?: DevelopmentOperations;
+  storage?: StorageOperations;
+  branching?: BranchingOperations;
 };

--- a/packages/mcp-server-supabase/src/pricing.ts
+++ b/packages/mcp-server-supabase/src/pricing.ts
@@ -1,4 +1,4 @@
-import type { SupabasePlatform } from './platform/types.js';
+import type { AccountOperations } from './platform/types.js';
 
 export const PROJECT_COST_MONTHLY = 10;
 export const BRANCH_COST_HOURLY = 0.01344;
@@ -21,11 +21,11 @@ export type Cost = ProjectCost | BranchCost;
  * Gets the cost of the next project in an organization.
  */
 export async function getNextProjectCost(
-  platform: SupabasePlatform,
+  account: AccountOperations,
   orgId: string
 ): Promise<Cost> {
-  const org = await platform.getOrganization(orgId);
-  const projects = await platform.listProjects();
+  const org = await account.getOrganization(orgId);
+  const projects = await account.listProjects();
 
   const activeProjects = projects.filter(
     (project) =>

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -25,6 +25,7 @@ import {
 import { createSupabaseApiPlatform } from './platform/api-platform.js';
 import { BRANCH_COST_HOURLY, PROJECT_COST_MONTHLY } from './pricing.js';
 import { createSupabaseMcpServer } from './server.js';
+import type { SupabasePlatform } from './platform/types.js';
 
 beforeEach(async () => {
   mockOrgs.clear();
@@ -38,6 +39,7 @@ beforeEach(async () => {
 type SetupOptions = {
   accessToken?: string;
   projectId?: string;
+  platform?: SupabasePlatform;
   readOnly?: boolean;
   features?: string[];
 };
@@ -63,10 +65,12 @@ async function setup(options: SetupOptions = {}) {
     }
   );
 
-  const platform = createSupabaseApiPlatform({
-    accessToken,
-    apiUrl: API_URL,
-  });
+  const platform =
+    options.platform ??
+    createSupabaseApiPlatform({
+      accessToken,
+      apiUrl: API_URL,
+    });
 
   const server = createSupabaseMcpServer({
     platform,
@@ -2241,6 +2245,35 @@ describe('feature groups', () => {
       'create_project',
       'pause_project',
       'restore_project',
+    ]);
+  });
+
+  test('tools filtered to available platform operations', async () => {
+    const platform: SupabasePlatform = {
+      database: {
+        executeSql() {
+          throw new Error('Not implemented');
+        },
+        listMigrations() {
+          throw new Error('Not implemented');
+        },
+        applyMigration() {
+          throw new Error('Not implemented');
+        },
+      },
+    };
+
+    const { client } = await setup({ platform });
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
+
+    expect(toolNames).toEqual([
+      'search_docs',
+      'list_tables',
+      'list_extensions',
+      'list_migrations',
+      'apply_migration',
+      'execute_sql',
     ]);
   });
 });

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -24,7 +24,7 @@ import {
 } from '../test/mocks.js';
 import { createSupabaseApiPlatform } from './platform/api-platform.js';
 import { BRANCH_COST_HOURLY, PROJECT_COST_MONTHLY } from './pricing.js';
-import { createSupabaseMcpServer, type FeatureGroup } from './server.js';
+import { createSupabaseMcpServer } from './server.js';
 
 beforeEach(async () => {
   mockOrgs.clear();
@@ -39,7 +39,7 @@ type SetupOptions = {
   accessToken?: string;
   projectId?: string;
   readOnly?: boolean;
-  features?: FeatureGroup[];
+  features?: string[];
 };
 
 /**
@@ -2097,14 +2097,14 @@ describe('tools', () => {
 
 describe('feature groups', () => {
   test('account tools', async () => {
-    const { client: accountClient } = await setup({
+    const { client } = await setup({
       features: ['account'],
     });
 
-    const { tools: accountTools } = await accountClient.listTools();
-    const accountToolNames = accountTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(accountToolNames).toEqual([
+    expect(toolNames).toEqual([
       'list_organizations',
       'get_organization',
       'list_projects',
@@ -2118,14 +2118,14 @@ describe('feature groups', () => {
   });
 
   test('database tools', async () => {
-    const { client: databaseClient } = await setup({
+    const { client } = await setup({
       features: ['database'],
     });
 
-    const { tools: databaseTools } = await databaseClient.listTools();
-    const databaseToolNames = databaseTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(databaseToolNames).toEqual([
+    expect(toolNames).toEqual([
       'list_tables',
       'list_extensions',
       'list_migrations',
@@ -2134,26 +2134,26 @@ describe('feature groups', () => {
     ]);
   });
 
-  test('debug tools', async () => {
-    const { client: debugClient } = await setup({
-      features: ['debug'],
+  test('debugging tools', async () => {
+    const { client } = await setup({
+      features: ['debugging'],
     });
 
-    const { tools: debugTools } = await debugClient.listTools();
-    const debugToolNames = debugTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(debugToolNames).toEqual(['get_logs', 'get_advisors']);
+    expect(toolNames).toEqual(['get_logs', 'get_advisors']);
   });
 
   test('development tools', async () => {
-    const { client: developmentClient } = await setup({
+    const { client } = await setup({
       features: ['development'],
     });
 
-    const { tools: developmentTools } = await developmentClient.listTools();
-    const developmentToolNames = developmentTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(developmentToolNames).toEqual([
+    expect(toolNames).toEqual([
       'get_project_url',
       'get_anon_key',
       'generate_typescript_types',
@@ -2161,39 +2161,36 @@ describe('feature groups', () => {
   });
 
   test('docs tools', async () => {
-    const { client: docsClient } = await setup({
+    const { client } = await setup({
       features: ['docs'],
     });
 
-    const { tools: docsTools } = await docsClient.listTools();
-    const docsToolNames = docsTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(docsToolNames).toEqual(['search_docs']);
+    expect(toolNames).toEqual(['search_docs']);
   });
 
   test('functions tools', async () => {
-    const { client: functionsClient } = await setup({
+    const { client } = await setup({
       features: ['functions'],
     });
 
-    const { tools: functionsTools } = await functionsClient.listTools();
-    const functionsToolNames = functionsTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(functionsToolNames).toEqual([
-      'list_edge_functions',
-      'deploy_edge_function',
-    ]);
+    expect(toolNames).toEqual(['list_edge_functions', 'deploy_edge_function']);
   });
 
   test('branching tools', async () => {
-    const { client: branchingClient } = await setup({
+    const { client } = await setup({
       features: ['branching'],
     });
 
-    const { tools: branchingTools } = await branchingClient.listTools();
-    const branchingToolNames = branchingTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(branchingToolNames).toEqual([
+    expect(toolNames).toEqual([
       'create_branch',
       'list_branches',
       'delete_branch',
@@ -2204,14 +2201,14 @@ describe('feature groups', () => {
   });
 
   test('storage tools', async () => {
-    const { client: storageClient } = await setup({
+    const { client } = await setup({
       features: ['storage'],
     });
 
-    const { tools: storageTools } = await storageClient.listTools();
-    const storageToolNames = storageTools.map((tool) => tool.name);
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(storageToolNames).toEqual([
+    expect(toolNames).toEqual([
       'list_storage_buckets',
       'get_storage_config',
       'update_storage_config',
@@ -2220,7 +2217,7 @@ describe('feature groups', () => {
 
   test('invalid group fails', async () => {
     const setupPromise = setup({
-      features: ['my-invalid-group' as FeatureGroup],
+      features: ['my-invalid-group'],
     });
 
     await expect(setupPromise).rejects.toThrow('Invalid enum value');
@@ -2231,10 +2228,10 @@ describe('feature groups', () => {
       features: ['account', 'account'],
     });
 
-    const { tools: duplicateTools } = await duplicateClient.listTools();
-    const duplicateToolNames = duplicateTools.map((tool) => tool.name);
+    const { tools } = await duplicateClient.listTools();
+    const toolNames = tools.map((tool) => tool.name);
 
-    expect(duplicateToolNames).toEqual([
+    expect(toolNames).toEqual([
       'list_organizations',
       'get_organization',
       'list_projects',

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -1,16 +1,17 @@
 import { createMcpServer, type Tool } from '@supabase/mcp-utils';
-import { z } from 'zod';
 import packageJson from '../package.json' with { type: 'json' };
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { getAccountTools } from './tools/account-tools.js';
 import { getBranchingTools } from './tools/branching-tools.js';
-import { getDatabaseOperationTools } from './tools/database-operation-tools.js';
+import { getDatabaseTools } from './tools/database-operation-tools.js';
 import { getDebuggingTools } from './tools/debugging-tools.js';
 import { getDevelopmentTools } from './tools/development-tools.js';
 import { getDocsTools } from './tools/docs-tools.js';
 import { getEdgeFunctionTools } from './tools/edge-function-tools.js';
 import { getStorageTools } from './tools/storage-tools.js';
+import type { FeatureGroup } from './types.js';
+import { parseFeatureGroups } from './util.js';
 
 const { version } = packageJson;
 
@@ -52,33 +53,22 @@ export type SupabaseMcpServerOptions = {
 
   /**
    * Features to enable.
-   * Options: 'account', 'branching', 'database', 'debug', 'development', 'docs', 'functions', 'storage'
+   * Options: 'account', 'branching', 'database', 'debugging', 'development', 'docs', 'functions', 'storage'
    */
   features?: string[];
 };
-
-const featureGroupSchema = z.enum([
-  'docs',
-  'account',
-  'database',
-  'debug',
-  'development',
-  'functions',
-  'branching',
-  'storage',
-]);
-
-export type FeatureGroup = z.infer<typeof featureGroupSchema>;
 
 const DEFAULT_FEATURES: FeatureGroup[] = [
   'docs',
   'account',
   'database',
-  'debug',
+  'debugging',
   'development',
   'functions',
   'branching',
 ];
+
+export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];
 
 /**
  * Creates an MCP server for interacting with Supabase.
@@ -94,9 +84,18 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
 
   const contentApiClientPromise = createContentApiClient(contentApiUrl);
 
-  const enabledFeatures = z
-    .set(featureGroupSchema)
-    .parse(new Set(features ?? DEFAULT_FEATURES));
+  // Filter the default features based on the platform's capabilities
+  const availableDefaultFeatures = DEFAULT_FEATURES.filter(
+    (key) =>
+      PLATFORM_INDEPENDENT_FEATURES.includes(key) ||
+      Object.keys(platform).includes(key)
+  );
+
+  // Validate the desired features against the platform's available features
+  const enabledFeatures = parseFeatureGroups(
+    platform,
+    features ?? availableDefaultFeatures
+  );
 
   const server = createMcpServer({
     name: 'supabase',
@@ -110,40 +109,53 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       const contentApiClient = await contentApiClientPromise;
       const tools: Record<string, Tool> = {};
 
-      // Add feature-based tools
-      if (!projectId && enabledFeatures.has('account')) {
-        Object.assign(tools, getAccountTools({ platform }));
-      }
-
-      if (enabledFeatures.has('branching')) {
-        Object.assign(tools, getBranchingTools({ platform, projectId }));
-      }
-
-      if (enabledFeatures.has('database')) {
-        Object.assign(
-          tools,
-          getDatabaseOperationTools({ platform, projectId, readOnly })
-        );
-      }
-
-      if (enabledFeatures.has('debug')) {
-        Object.assign(tools, getDebuggingTools({ platform, projectId }));
-      }
-
-      if (enabledFeatures.has('development')) {
-        Object.assign(tools, getDevelopmentTools({ platform, projectId }));
-      }
+      const {
+        account,
+        database,
+        functions,
+        debugging,
+        development,
+        storage,
+        branching,
+      } = platform;
 
       if (enabledFeatures.has('docs')) {
         Object.assign(tools, getDocsTools({ contentApiClient }));
       }
 
-      if (enabledFeatures.has('functions')) {
-        Object.assign(tools, getEdgeFunctionTools({ platform, projectId }));
+      if (!projectId && account && enabledFeatures.has('account')) {
+        Object.assign(tools, getAccountTools({ account }));
       }
 
-      if (enabledFeatures.has('storage')) {
-        Object.assign(tools, getStorageTools({ platform, projectId }));
+      if (database && enabledFeatures.has('database')) {
+        Object.assign(
+          tools,
+          getDatabaseTools({
+            database,
+            projectId,
+            readOnly,
+          })
+        );
+      }
+
+      if (debugging && enabledFeatures.has('debugging')) {
+        Object.assign(tools, getDebuggingTools({ debugging, projectId }));
+      }
+
+      if (development && enabledFeatures.has('development')) {
+        Object.assign(tools, getDevelopmentTools({ development, projectId }));
+      }
+
+      if (functions && enabledFeatures.has('functions')) {
+        Object.assign(tools, getEdgeFunctionTools({ functions, projectId }));
+      }
+
+      if (branching && enabledFeatures.has('branching')) {
+        Object.assign(tools, getBranchingTools({ branching, projectId }));
+      }
+
+      if (storage && enabledFeatures.has('storage')) {
+        Object.assign(tools, getStorageTools({ storage, projectId }));
       }
 
       return tools;

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -1,21 +1,21 @@
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { AccountOperations } from '../platform/types.js';
 import { type Cost, getBranchCost, getNextProjectCost } from '../pricing.js';
 import { AWS_REGION_CODES } from '../regions.js';
 import { hashObject } from '../util.js';
 
 export type AccountToolsOptions = {
-  platform: SupabasePlatform;
+  account: AccountOperations;
 };
 
-export function getAccountTools({ platform }: AccountToolsOptions) {
+export function getAccountTools({ account }: AccountToolsOptions) {
   return {
     list_organizations: tool({
       description: 'Lists all organizations that the user is a member of.',
       parameters: z.object({}),
       execute: async () => {
-        return await platform.listOrganizations();
+        return await account.listOrganizations();
       },
     }),
     get_organization: tool({
@@ -25,7 +25,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
         id: z.string().describe('The organization ID'),
       }),
       execute: async ({ id: organizationId }) => {
-        return await platform.getOrganization(organizationId);
+        return await account.getOrganization(organizationId);
       },
     }),
     list_projects: tool({
@@ -33,7 +33,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
         'Lists all Supabase projects for the user. Use this to help discover the project ID of the project that the user is working on.',
       parameters: z.object({}),
       execute: async () => {
-        return await platform.listProjects();
+        return await account.listProjects();
       },
     }),
     get_project: tool({
@@ -42,7 +42,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
         id: z.string().describe('The project ID'),
       }),
       execute: async ({ id }) => {
-        return await platform.getProject(id);
+        return await account.getProject(id);
       },
     }),
     get_cost: tool({
@@ -60,7 +60,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
         }
         switch (type) {
           case 'project': {
-            const cost = await getNextProjectCost(platform, organization_id);
+            const cost = await getNextProjectCost(account, organization_id);
             return generateResponse(cost);
           }
           case 'branch': {
@@ -105,7 +105,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
           .describe('The cost confirmation ID. Call `confirm_cost` first.'),
       }),
       execute: async ({ name, region, organization_id, confirm_cost_id }) => {
-        const cost = await getNextProjectCost(platform, organization_id);
+        const cost = await getNextProjectCost(account, organization_id);
         const costHash = await hashObject(cost);
         if (costHash !== confirm_cost_id) {
           throw new Error(
@@ -113,7 +113,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
           );
         }
 
-        return await platform.createProject({
+        return await account.createProject({
           name,
           region,
           organization_id,
@@ -126,7 +126,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
         project_id: z.string(),
       }),
       execute: async ({ project_id }) => {
-        return await platform.pauseProject(project_id);
+        return await account.pauseProject(project_id);
       },
     }),
     restore_project: tool({
@@ -135,7 +135,7 @@ export function getAccountTools({ platform }: AccountToolsOptions) {
         project_id: z.string(),
       }),
       execute: async ({ project_id }) => {
-        return await platform.restoreProject(project_id);
+        return await account.restoreProject(project_id);
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -1,17 +1,17 @@
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { BranchingOperations } from '../platform/types.js';
 import { getBranchCost } from '../pricing.js';
 import { hashObject } from '../util.js';
 import { injectableTool } from './util.js';
 
 export type BranchingToolsOptions = {
-  platform: SupabasePlatform;
+  branching: BranchingOperations;
   projectId?: string;
 };
 
 export function getBranchingTools({
-  platform,
+  branching,
   projectId,
 }: BranchingToolsOptions) {
   const project_id = projectId;
@@ -42,7 +42,7 @@ export function getBranchingTools({
             'Cost confirmation ID does not match the expected cost of creating a branch.'
           );
         }
-        return await platform.createBranch(project_id, { name });
+        return await branching.createBranch(project_id, { name });
       },
     }),
     list_branches: injectableTool({
@@ -53,7 +53,7 @@ export function getBranchingTools({
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return await platform.listBranches(project_id);
+        return await branching.listBranches(project_id);
       },
     }),
     delete_branch: tool({
@@ -62,7 +62,7 @@ export function getBranchingTools({
         branch_id: z.string(),
       }),
       execute: async ({ branch_id }) => {
-        return await platform.deleteBranch(branch_id);
+        return await branching.deleteBranch(branch_id);
       },
     }),
     merge_branch: tool({
@@ -72,7 +72,7 @@ export function getBranchingTools({
         branch_id: z.string(),
       }),
       execute: async ({ branch_id }) => {
-        return await platform.mergeBranch(branch_id);
+        return await branching.mergeBranch(branch_id);
       },
     }),
     reset_branch: tool({
@@ -88,7 +88,7 @@ export function getBranchingTools({
           ),
       }),
       execute: async ({ branch_id, migration_version }) => {
-        return await platform.resetBranch(branch_id, {
+        return await branching.resetBranch(branch_id, {
           migration_version,
         });
       },
@@ -100,7 +100,7 @@ export function getBranchingTools({
         branch_id: z.string(),
       }),
       execute: async ({ branch_id }) => {
-        return await platform.rebaseBranch(branch_id);
+        return await branching.rebaseBranch(branch_id);
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -5,17 +5,17 @@ import {
   postgresExtensionSchema,
   postgresTableSchema,
 } from '../pg-meta/types.js';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { DatabaseOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
 export type DatabaseOperationToolsOptions = {
-  platform: SupabasePlatform;
+  database: DatabaseOperations;
   projectId?: string;
   readOnly?: boolean;
 };
 
-export function getDatabaseOperationTools({
-  platform,
+export function getDatabaseTools({
+  database,
   projectId,
   readOnly,
 }: DatabaseOperationToolsOptions) {
@@ -34,7 +34,7 @@ export function getDatabaseOperationTools({
       inject: { project_id },
       execute: async ({ project_id, schemas }) => {
         const query = listTablesSql(schemas);
-        const data = await platform.executeSql(project_id, {
+        const data = await database.executeSql(project_id, {
           query,
           read_only: readOnly,
         });
@@ -50,7 +50,7 @@ export function getDatabaseOperationTools({
       inject: { project_id },
       execute: async ({ project_id }) => {
         const query = listExtensionsSql();
-        const data = await platform.executeSql(project_id, {
+        const data = await database.executeSql(project_id, {
           query,
           read_only: readOnly,
         });
@@ -67,7 +67,7 @@ export function getDatabaseOperationTools({
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return await platform.listMigrations(project_id);
+        return await database.listMigrations(project_id);
       },
     }),
     apply_migration: injectableTool({
@@ -84,7 +84,7 @@ export function getDatabaseOperationTools({
           throw new Error('Cannot apply migration in read-only mode.');
         }
 
-        await platform.applyMigration(project_id, {
+        await database.applyMigration(project_id, {
           name,
           query,
         });
@@ -101,7 +101,7 @@ export function getDatabaseOperationTools({
       }),
       inject: { project_id },
       execute: async ({ query, project_id }) => {
-        const result = await platform.executeSql(project_id, {
+        const result = await database.executeSql(project_id, {
           query,
           read_only: readOnly,
         });

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -1,15 +1,15 @@
 import { z } from 'zod';
 import { getLogQuery } from '../logs.js';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { DebuggingOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
 export type DebuggingToolsOptions = {
-  platform: SupabasePlatform;
+  debugging: DebuggingOperations;
   projectId?: string;
 };
 
 export function getDebuggingTools({
-  platform,
+  debugging,
   projectId,
 }: DebuggingToolsOptions) {
   const project_id = projectId;
@@ -42,7 +42,7 @@ export function getDebuggingTools({
             ? new Date(Date.now() - 5 * 60 * 1000)
             : undefined;
 
-        return platform.getLogs(project_id, {
+        return debugging.getLogs(project_id, {
           sql: getLogQuery(service),
           iso_timestamp_start: startTimestamp?.toISOString(),
         });
@@ -61,9 +61,9 @@ export function getDebuggingTools({
       execute: async ({ project_id, type }) => {
         switch (type) {
           case 'security':
-            return platform.getSecurityAdvisors(project_id);
+            return debugging.getSecurityAdvisors(project_id);
           case 'performance':
-            return platform.getPerformanceAdvisors(project_id);
+            return debugging.getPerformanceAdvisors(project_id);
           default:
             throw new Error(`Unknown advisor type: ${type}`);
         }

--- a/packages/mcp-server-supabase/src/tools/development-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/development-tools.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { DevelopmentOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
 export type DevelopmentToolsOptions = {
-  platform: SupabasePlatform;
+  development: DevelopmentOperations;
   projectId?: string;
 };
 
 export function getDevelopmentTools({
-  platform,
+  development,
   projectId,
 }: DevelopmentToolsOptions) {
   const project_id = projectId;
@@ -21,7 +21,7 @@ export function getDevelopmentTools({
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return platform.getProjectUrl(project_id);
+        return development.getProjectUrl(project_id);
       },
     }),
     get_anon_key: injectableTool({
@@ -31,7 +31,7 @@ export function getDevelopmentTools({
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return platform.getAnonKey(project_id);
+        return development.getAnonKey(project_id);
       },
     }),
     generate_typescript_types: injectableTool({
@@ -41,7 +41,7 @@ export function getDevelopmentTools({
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return platform.generateTypescriptTypes(project_id);
+        return development.generateTypescriptTypes(project_id);
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/tools/edge-function-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/edge-function-tools.ts
@@ -1,15 +1,15 @@
 import { z } from 'zod';
 import { edgeFunctionExample } from '../edge-function.js';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { EdgeFunctionsOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
 export type EdgeFunctionToolsOptions = {
-  platform: SupabasePlatform;
+  functions: EdgeFunctionsOperations;
   projectId?: string;
 };
 
 export function getEdgeFunctionTools({
-  platform,
+  functions,
   projectId,
 }: EdgeFunctionToolsOptions) {
   const project_id = projectId;
@@ -22,7 +22,7 @@ export function getEdgeFunctionTools({
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return await platform.listEdgeFunctions(project_id);
+        return await functions.listEdgeFunctions(project_id);
       },
     }),
     deploy_edge_function: injectableTool({
@@ -57,7 +57,7 @@ export function getEdgeFunctionTools({
         import_map_path,
         files,
       }) => {
-        return await platform.deployEdgeFunction(project_id, {
+        return await functions.deployEdgeFunction(project_id, {
           name,
           entrypoint_path,
           import_map_path,

--- a/packages/mcp-server-supabase/src/tools/storage-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/storage-tools.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
-import type { SupabasePlatform } from '../platform/types.js';
+import type { StorageOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
 export type StorageToolsOptions = {
-  platform: SupabasePlatform;
+  storage: StorageOperations;
   projectId?: string;
 };
 
-export function getStorageTools({ platform, projectId }: StorageToolsOptions) {
+export function getStorageTools({ storage, projectId }: StorageToolsOptions) {
   const project_id = projectId;
 
   return {
@@ -18,7 +18,7 @@ export function getStorageTools({ platform, projectId }: StorageToolsOptions) {
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return await platform.listAllBuckets(project_id);
+        return await storage.listAllBuckets(project_id);
       },
     }),
     get_storage_config: injectableTool({
@@ -28,7 +28,7 @@ export function getStorageTools({ platform, projectId }: StorageToolsOptions) {
       }),
       inject: { project_id },
       execute: async ({ project_id }) => {
-        return await platform.getStorageConfig(project_id);
+        return await storage.getStorageConfig(project_id);
       },
     }),
     update_storage_config: injectableTool({
@@ -45,7 +45,7 @@ export function getStorageTools({ platform, projectId }: StorageToolsOptions) {
       }),
       inject: { project_id },
       execute: async ({ project_id, config }) => {
-        await platform.updateStorageConfig(project_id, config);
+        await storage.updateStorageConfig(project_id, config);
         return { success: true };
       },
     }),

--- a/packages/mcp-server-supabase/src/types.ts
+++ b/packages/mcp-server-supabase/src/types.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const featureGroupSchema = z.enum([
+  'docs',
+  'account',
+  'database',
+  'debugging',
+  'development',
+  'functions',
+  'branching',
+  'storage',
+]);
+
+export type FeatureGroup = z.infer<typeof featureGroupSchema>;


### PR DESCRIPTION
Supabase MCP supports custom [platform implementations ](https://github.com/supabase-community/supabase-mcp/pull/78) based on the environment it is running in. This PR makes this even more flexible by allowing you to implement only a subset of platform operations.

Before:

```ts
const myPlatform: SupabasePlatform = {
  executeSql() { ... },
  listMigrations() { ... },
  applyMigration() { ... },
  // every other possible platform operations
}
```

After:

```ts
const myPlatform: SupabasePlatform = {
  database: {
    executeSql() { ... },
    listMigrations() { ... },
    applyMigration() { ... },
  },
  // intentionally don't implement anything else
}

### Why
Self-hosted Supabase can support some but not all platform operations (e.g. it can't support account level or branching operations). In order to make this MCP server [compatible with self-hosted](https://github.com/supabase-community/supabase-mcp/pull/92), we need a way to conditionally implement platform operations.

### How
Now that we support [feature groups](https://github.com/supabase-community/supabase-mcp/pull/98), we can extend this logic to also filter by platform operations. The `SupabasePlatform` interface is now grouped by feature (`database`, `account`, `functions`, etc) and each group is optional. We add logic in the server that conditionally adds tools only if the platform methods for that group are implemented.