### PR TITLE
fix: type checking

### DIFF
--- a/packages/mcp-server-postgrest/package.json
+++ b/packages/mcp-server-postgrest/package.json
@@ -9,6 +9,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "prebuild": "pnpm typecheck",
     "prepublishOnly": "pnpm build",
     "test": "vitest"
   },

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -9,6 +9,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "prebuild": "pnpm typecheck",
     "prepublishOnly": "pnpm build",
     "test": "vitest",
     "test:unit": "vitest --project unit",
@@ -17,9 +20,7 @@
     "test:coverage": "vitest --coverage",
     "generate:management-api-types": "openapi-typescript https://api.supabase.com/api/v1-json -o ./src/management-api/types.ts"
   },
-  "files": [
-    "dist/**/*"
-  ],
+  "files": ["dist/**/*"],
   "bin": {
     "mcp-server-supabase": "./dist/transports/stdio.js"
   },

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -91,9 +91,7 @@ export function getAccountTools({ account }: AccountToolsOptions) {
         name: z.string().describe('The name of the project'),
         region: z
           .enum(AWS_REGION_CODES)
-          .describe(
-            'The region to create the project in. Defaults to the closest region.'
-          ),
+          .describe('The region to create the project in.'),
         organization_id: z.string(),
         confirm_cost_id: z
           .string({

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -89,13 +89,11 @@ export function getAccountTools({ account }: AccountToolsOptions) {
         'Creates a new Supabase project. Always ask the user which organization to create the project in. The project can take a few minutes to initialize - use `get_project` to check the status.',
       parameters: z.object({
         name: z.string().describe('The name of the project'),
-        region: z.optional(
-          z
-            .enum(AWS_REGION_CODES)
-            .describe(
-              'The region to create the project in. Defaults to the closest region.'
-            )
-        ),
+        region: z
+          .enum(AWS_REGION_CODES)
+          .describe(
+            'The region to create the project in. Defaults to the closest region.'
+          ),
         organization_id: z.string(),
         confirm_cost_id: z
           .string({

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -9,6 +9,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup --clean",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "prebuild": "pnpm typecheck",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "prepublishOnly": "pnpm build"


### PR DESCRIPTION
- Adds "typecheck" script that runs TypeScript compiler
- Runs "typecheck" during "prebuild" so that it runs with `pnpm build` before tsup
- Adds "dev" script for running tsup in watch mode (rebuilds on change)
- Fixed type error in `account-tools.ts` that was overlooked in #130 