### PR TITLE
feat: export `currentFeatureGroupSchema`

### DIFF
--- a/packages/mcp-server-supabase/src/index.ts
+++ b/packages/mcp-server-supabase/src/index.ts
@@ -3,4 +3,8 @@ export {
   createSupabaseMcpServer,
   type SupabaseMcpServerOptions,
 } from './server.js';
-export { featureGroupSchema, type FeatureGroup } from './types.js';
+export {
+  featureGroupSchema,
+  currentFeatureGroupSchema,
+  type FeatureGroup,
+} from './types.js';


### PR DESCRIPTION
As of #103 the exported `featureGroupSchema` is no longer a plain Zod enum, and is a union of deprecated and current feature group.

Export the current feature group schema (a plain Zod enum) so we can read the list of `.options` and consider only non-deprecated feature groups for remote MCP.