### PR TITLE
feat: `onToolCall` callback

### DIFF
--- a/packages/mcp-server-supabase/src/index.ts
+++ b/packages/mcp-server-supabase/src/index.ts
@@ -1,5 +1,6 @@
 import packageJson from '../package.json' with { type: 'json' };
 
+export type { ToolCallCallback } from '@supabase/mcp-utils';
 export type { SupabasePlatform } from './platform/index.js';
 export {
   createSupabaseMcpServer,

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -1,4 +1,8 @@
-import { createMcpServer, type Tool } from '@supabase/mcp-utils';
+import {
+  createMcpServer,
+  type Tool,
+  type ToolCallCallback,
+} from '@supabase/mcp-utils';
 import packageJson from '../package.json' with { type: 'json' };
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
@@ -44,6 +48,11 @@ export type SupabaseMcpServerOptions = {
    * Options: 'account', 'branching', 'database', 'debugging', 'development', 'docs', 'functions', 'storage'
    */
   features?: string[];
+
+  /**
+   * Callback for after a supabase tool is called.
+   */
+  onToolCall?: ToolCallCallback;
 };
 
 const DEFAULT_FEATURES: FeatureGroup[] = [
@@ -68,6 +77,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     readOnly,
     features,
     contentApiUrl = 'https://supabase.com/docs/api/graphql',
+    onToolCall,
   } = options;
 
   const contentApiClientPromise = createContentApiClient(contentApiUrl, {
@@ -104,6 +114,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         ),
       ]);
     },
+    onToolCall,
     tools: async () => {
       const contentApiClient = await contentApiClientPromise;
       const tools: Record<string, Tool> = {};

--- a/packages/mcp-utils/src/server.test.ts
+++ b/packages/mcp-utils/src/server.test.ts
@@ -115,7 +115,7 @@ describe('tools', () => {
     });
   });
 
-  test('tool callback is called for success', async () => {
+  test('tool callback is called for success and errors', async () => {
     const onToolCall = vi.fn();
 
     const server = createMcpServer({

--- a/packages/mcp-utils/src/server.test.ts
+++ b/packages/mcp-utils/src/server.test.ts
@@ -129,9 +129,9 @@ describe('tools', () => {
             title: 'Good tool',
             readOnlyHint: true,
           },
-          parameters: z.object({}),
-          execute: async () => {
-            return 'Success';
+          parameters: z.object({ foo: z.string() }),
+          execute: async ({ foo }) => {
+            return `Success: ${foo}`;
           },
         }),
         bad_tool: tool({
@@ -140,9 +140,9 @@ describe('tools', () => {
             title: 'Bad tool',
             readOnlyHint: true,
           },
-          parameters: z.object({}),
-          execute: async () => {
-            throw new Error('Failure');
+          parameters: z.object({ foo: z.string() }),
+          execute: async ({ foo }) => {
+            throw new Error('Failure: ' + foo);
           },
         }),
       },
@@ -152,32 +152,36 @@ describe('tools', () => {
 
     const goodToolPromise = callTool({
       name: 'good_tool',
-      arguments: {},
+      arguments: { foo: 'bar' },
     });
 
-    await expect(goodToolPromise).resolves.toEqual('Success');
+    await expect(goodToolPromise).resolves.toEqual('Success: bar');
     expect(onToolCall).toHaveBeenLastCalledWith({
       name: 'good_tool',
-      success: true,
+      arguments: { foo: 'bar' },
       annotations: {
         title: 'Good tool',
         readOnlyHint: true,
       },
+      success: true,
+      data: 'Success: bar',
     });
 
     const badToolPromise = callTool({
       name: 'bad_tool',
-      arguments: {},
+      arguments: { foo: 'bar' },
     });
 
-    await expect(badToolPromise).rejects.toThrow('Failure');
+    await expect(badToolPromise).rejects.toThrow('Failure: bar');
     expect(onToolCall).toHaveBeenLastCalledWith({
       name: 'bad_tool',
-      success: false,
+      arguments: { foo: 'bar' },
       annotations: {
         title: 'Bad tool',
         readOnlyHint: true,
       },
+      success: false,
+      error: expect.any(Error),
     });
   });
 
@@ -197,9 +201,9 @@ describe('tools', () => {
             title: 'Good tool',
             readOnlyHint: true,
           },
-          parameters: z.object({}),
-          execute: async () => {
-            return 'Success';
+          parameters: z.object({ foo: z.string() }),
+          execute: async ({ foo }) => {
+            return `Success: ${foo}`;
           },
         }),
       },
@@ -209,10 +213,10 @@ describe('tools', () => {
 
     const goodToolPromise = callTool({
       name: 'good_tool',
-      arguments: {},
+      arguments: { foo: 'bar' },
     });
 
-    await expect(goodToolPromise).resolves.toEqual('Success');
+    await expect(goodToolPromise).resolves.toEqual('Success: bar');
     expect(onToolCall.mock.results[0]?.type).toBe('throw');
   });
 });

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -176,9 +176,9 @@ export type InitData = {
 };
 
 export type ToolCallDetails = {
-  name: string; // unique tool name
-  success: boolean; // whether the tool ran successfully or not
-  annotations?: Annotations; // annotations for the tool
+  name: string;
+  success: boolean;
+  annotations?: Annotations;
 };
 
 export type InitCallback = (initData: InitData) => void | Promise<void>;

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -182,9 +182,7 @@ export type ToolCallDetails = {
 };
 
 export type InitCallback = (initData: InitData) => void | Promise<void>;
-export type ToolCallCallback = (
-  details: ToolCallDetails
-) => void | Promise<void>;
+export type ToolCallCallback = (details: ToolCallDetails) => void;
 export type PropCallback<T> = () => T | Promise<T>;
 export type Prop<T> = T | PropCallback<T>;
 
@@ -473,16 +471,16 @@ export function createMcpServer(options: McpServerOptions) {
             .then((data: unknown) => ({ success: true as const, data }))
             .catch((error) => ({ success: false as const, error }));
 
-          // Run callback without blocking the tool call
-          options
-            .onToolCall?.({
+          try {
+            options.onToolCall?.({
               name: toolName,
               success: res.success,
               annotations: tool.annotations,
-            })
-            ?.catch((error) => {
-              console.error('Failed to run tool callback', error);
             });
+          } catch (error) {
+            // Don't fail the tool call if the callback fails
+            console.error('Failed to run tool callback', error);
+          }
 
           // Unwrap result
           if (!res.success) {

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -175,11 +175,23 @@ export type InitData = {
   clientCapabilities: ClientCapabilities;
 };
 
-export type ToolCallDetails = {
+type ToolCallBaseDetails = {
   name: string;
-  success: boolean;
+  arguments: Record<string, unknown>;
   annotations?: Annotations;
 };
+
+type ToolCallSuccessDetails = ToolCallBaseDetails & {
+  success: true;
+  data: unknown;
+};
+
+type ToolCallErrorDetails = ToolCallBaseDetails & {
+  success: false;
+  error: unknown;
+};
+
+export type ToolCallDetails = ToolCallSuccessDetails | ToolCallErrorDetails;
 
 export type InitCallback = (initData: InitData) => void | Promise<void>;
 export type ToolCallCallback = (details: ToolCallDetails) => void;
@@ -474,8 +486,9 @@ export function createMcpServer(options: McpServerOptions) {
           try {
             options.onToolCall?.({
               name: toolName,
-              success: res.success,
+              arguments: args,
               annotations: tool.annotations,
+              ...res,
             });
           } catch (error) {
             // Don't fail the tool call if the callback fails

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -473,16 +473,16 @@ export function createMcpServer(options: McpServerOptions) {
             .then((data: unknown) => ({ success: true as const, data }))
             .catch((error) => ({ success: false as const, error }));
 
-          try {
-            await options.onToolCall?.({
+          // Run callback without blocking the tool call
+          options
+            .onToolCall?.({
               name: toolName,
               success: res.success,
               annotations: tool.annotations,
+            })
+            ?.catch((error) => {
+              console.error('Failed to run tool callback', error);
             });
-          } catch (error) {
-            // Don't fail the tool call if the callback fails
-            console.error('Failed to run tool callback', error);
-          }
 
           // Unwrap result
           if (!res.success) {


### PR DESCRIPTION
Adds an `onToolCall` callback to the options for:
- `createMcpServer` in `packages/mcp-utils`
- `createSupabaseMcpServer` in `packages/mcp-server-supabase`


The callback details contain the tool name, success flag, and [annotations](https://github.com/supabase-community/supabase-mcp/pull/144). If needed this could be further processed to only include `title` and `readOnly` flags, but I figured since those would be inferred from annotations anyways it makes sense to include the whole thing.

Tests are added to verify success/failure tracking and ensure that errors in this callback don't prohibit tool execution.

Resolves AI-117