### PR TITLE
docs: add remote MCP to README, remove stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ The Supabase MCP server is hosted at `https://mcp.supabase.com/mcp` and supports
 
 The easiest way to connect your MCP client (such as Cursor) to your project is clicking [Connect](https://supabase.com/dashboard/project/_?showConnect=true&tab=mcp) in the Supabase dashboard and navigating to the MCP tab. There you can choose options such as [feature groups](#feature-groups), and generate one-click installers or config entries for popular clients.
 
-![supabase-mcp-url-builder](https://github.com/user-attachments/assets/f77d4c40-24e2-49e2-aba8-2148b0b1788f)
-
 Most MCP clients store the configuration as JSON in the following format:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before setting up the MCP server, we recommend you read our [security best pract
 
 ### 2. Configure your MCP client
 
-The Supabase MCP server is hosted at `https://mcp.supabase.com/mcp` and supports the Streamable HTTP transport with OAuth authentication.
+The Supabase MCP server is hosted at `https://mcp.supabase.com/mcp` and supports the Streamable HTTP transport with OAuth authentication. If you're running Supabase locally with [Supabase CLI](https://supabase.com/docs/guides/local-development/cli/getting-started), you can access the MCP server at `http://localhost:54321/mcp` with a subset of tools.
 
 The easiest way to connect your MCP client (such as Cursor) to your project is clicking [Connect](https://supabase.com/dashboard/project/_?showConnect=true&tab=mcp) in the Supabase dashboard and navigating to the MCP tab. There you can choose options such as [feature groups](#feature-groups), and generate one-click installers or config entries for popular clients.
 


### PR DESCRIPTION
See [README.md preview](https://github.com/supabase-community/supabase-mcp/blob/docs/remote-mcp-readme/README.md)

- Adds remote MCP instructions, deep link to MCP tab of dashboard "Connect", and link to MCP docs
- Replaces CLI options syntax with query parameter syntax. I kept the explanations for the various options / tools since we don't go into detail on these in the docs.
- Removes `stdio` transport instructions

Resolves AI-149