### PR TITLE
feat(mcp-registry): add remote transport to server.json

### DIFF
--- a/packages/mcp-server-supabase/server.json
+++ b/packages/mcp-server-supabase/server.json
@@ -8,7 +8,14 @@
     "source": "github",
     "subfolder": "packages/mcp-server-supabase"
   },
+  "website_url": "https://supabase.com/mcp",
   "version": "0.5.5",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.supabase.com/mcp"
+    }
+  ],
   "packages": [
     {
       "registry_type": "npm",


### PR DESCRIPTION
Adds the `remotes` field to our MCP registry `server.json`. Also adds `website_url` pointing to our docs.