### PR TITLE
docs: add quick install button to README for Cursor and VSCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Your MCP client will automatically prompt you to login to Supabase during setup.
 
 For more information, visit the [Supabase MCP docs](https://supabase.com/docs/guides/getting-started/mcp).
 
-You can also manually install it on your favourite client.
+You can also manually install it on your favorite client.
 
 <details>
 <summary>Cursor</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the README to include an "Install server" button to README for Cursor and VSCode

## What is the current behavior?

Only instructions on how to manually install it

## What is the new behavior?

### Cursor

https://github.com/user-attachments/assets/a1509170-ee0d-4ce3-89b6-26ac5ebb52a2

### VSCode

https://github.com/user-attachments/assets/c69939a2-f627-4b01-8fa2-54a8e2919d62

### VSCode Insiders

https://github.com/user-attachments/assets/6f1f02db-b22d-45f2-88b1-1abac43b3f8a
