### PR TITLE
fix: return success response from void operations (AI-164)

### DIFF
--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -151,8 +151,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to pause project');
-
-      return SUCCESS_RESPONSE;
     },
     async restoreProject(projectId: string) {
       const response = await managementApiClient.POST(
@@ -167,8 +165,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to restore project');
-
-      return SUCCESS_RESPONSE;
     },
   };
 
@@ -236,7 +232,6 @@ export function createSupabaseApiPlatform(
       // Intentionally don't return the result of the migration
       // to avoid prompt injection attacks. If the migration failed,
       // it will throw an error.
-      return SUCCESS_RESPONSE;
     },
   };
 
@@ -620,8 +615,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to delete branch');
-
-      return SUCCESS_RESPONSE;
     },
     async mergeBranch(branchId: string) {
       const response = await managementApiClient.POST(
@@ -637,8 +630,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to merge branch');
-
-      return SUCCESS_RESPONSE;
     },
     async resetBranch(branchId: string, options: ResetBranchOptions) {
       const { migration_version } = resetBranchOptionsSchema.parse(options);
@@ -658,8 +649,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to reset branch');
-
-      return SUCCESS_RESPONSE;
     },
     async rebaseBranch(branchId: string) {
       const response = await managementApiClient.POST(
@@ -675,8 +664,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to rebase branch');
-
-      return SUCCESS_RESPONSE;
     },
   };
 
@@ -740,8 +727,6 @@ export function createSupabaseApiPlatform(
       );
 
       assertSuccess(response, 'Failed to update storage config');
-
-      return SUCCESS_RESPONSE;
     },
   };
 

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -181,7 +181,7 @@ export type DatabaseOperations = {
   applyMigration(
     projectId: string,
     options: ApplyMigrationOptions
-  ): Promise<SuccessResponse>;
+  ): Promise<void>;
 };
 
 export type AccountOperations = {
@@ -190,8 +190,8 @@ export type AccountOperations = {
   listProjects(): Promise<Project[]>;
   getProject(projectId: string): Promise<Project>;
   createProject(options: CreateProjectOptions): Promise<Project>;
-  pauseProject(projectId: string): Promise<SuccessResponse>;
-  restoreProject(projectId: string): Promise<SuccessResponse>;
+  pauseProject(projectId: string): Promise<void>;
+  restoreProject(projectId: string): Promise<void>;
 };
 
 export type EdgeFunctionsOperations = {
@@ -225,7 +225,7 @@ export type StorageOperations = {
   updateStorageConfig(
     projectId: string,
     config: StorageConfig
-  ): Promise<SuccessResponse>;
+  ): Promise<void>;
   listAllBuckets(projectId: string): Promise<StorageBucket[]>;
 };
 
@@ -235,13 +235,13 @@ export type BranchingOperations = {
     projectId: string,
     options: CreateBranchOptions
   ): Promise<Branch>;
-  deleteBranch(branchId: string): Promise<SuccessResponse>;
-  mergeBranch(branchId: string): Promise<SuccessResponse>;
+  deleteBranch(branchId: string): Promise<void>;
+  mergeBranch(branchId: string): Promise<void>;
   resetBranch(
     branchId: string,
     options: ResetBranchOptions
-  ): Promise<SuccessResponse>;
-  rebaseBranch(branchId: string): Promise<SuccessResponse>;
+  ): Promise<void>;
+  rebaseBranch(branchId: string): Promise<void>;
 };
 
 export type SupabasePlatform = {

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -5,6 +5,8 @@ import { type Cost, getBranchCost, getNextProjectCost } from '../pricing.js';
 import { AWS_REGION_CODES } from '../regions.js';
 import { hashObject } from '../util.js';
 
+const SUCCESS_RESPONSE = { success: true };
+
 export type AccountToolsOptions = {
   account: AccountOperations;
   readOnly?: boolean;
@@ -187,7 +189,8 @@ export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
           throw new Error('Cannot pause a project in read-only mode.');
         }
 
-        return await account.pauseProject(project_id);
+        await account.pauseProject(project_id);
+        return SUCCESS_RESPONSE;
       },
     }),
     restore_project: tool({
@@ -207,7 +210,8 @@ export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
           throw new Error('Cannot restore a project in read-only mode.');
         }
 
-        return await account.restoreProject(project_id);
+        await account.restoreProject(project_id);
+        return SUCCESS_RESPONSE;
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -5,6 +5,8 @@ import { getBranchCost } from '../pricing.js';
 import { hashObject } from '../util.js';
 import { injectableTool } from './util.js';
 
+const SUCCESS_RESPONSE = { success: true };
+
 export type BranchingToolsOptions = {
   branching: BranchingOperations;
   projectId?: string;
@@ -93,7 +95,8 @@ export function getBranchingTools({
           throw new Error('Cannot delete a branch in read-only mode.');
         }
 
-        return await branching.deleteBranch(branch_id);
+        await branching.deleteBranch(branch_id);
+        return SUCCESS_RESPONSE;
       },
     }),
     merge_branch: tool({
@@ -114,7 +117,8 @@ export function getBranchingTools({
           throw new Error('Cannot merge a branch in read-only mode.');
         }
 
-        return await branching.mergeBranch(branch_id);
+        await branching.mergeBranch(branch_id);
+        return SUCCESS_RESPONSE;
       },
     }),
     reset_branch: tool({
@@ -141,9 +145,10 @@ export function getBranchingTools({
           throw new Error('Cannot reset a branch in read-only mode.');
         }
 
-        return await branching.resetBranch(branch_id, {
+        await branching.resetBranch(branch_id, {
           migration_version,
         });
+        return SUCCESS_RESPONSE;
       },
     }),
     rebase_branch: tool({
@@ -164,7 +169,8 @@ export function getBranchingTools({
           throw new Error('Cannot rebase a branch in read-only mode.');
         }
 
-        return await branching.rebaseBranch(branch_id);
+        await branching.rebaseBranch(branch_id);
+        return SUCCESS_RESPONSE;
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -8,6 +8,8 @@ import {
 import type { DatabaseOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
+const SUCCESS_RESPONSE = { success: true };
+
 export type DatabaseOperationToolsOptions = {
   database: DatabaseOperations;
   projectId?: string;
@@ -218,7 +220,7 @@ export function getDatabaseTools({
           query,
         });
 
-        return { success: true };
+        return SUCCESS_RESPONSE;
       },
     }),
     execute_sql: injectableTool({

--- a/packages/mcp-server-supabase/src/tools/storage-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/storage-tools.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import type { StorageOperations } from '../platform/types.js';
 import { injectableTool } from './util.js';
 
+const SUCCESS_RESPONSE = { success: true };
+
 export type StorageToolsOptions = {
   storage: StorageOperations;
   projectId?: string;
@@ -76,7 +78,7 @@ export function getStorageTools({
         }
 
         await storage.updateStorageConfig(project_id, config);
-        return { success: true };
+        return SUCCESS_RESPONSE;
       },
     }),
   };


### PR DESCRIPTION
## Problem

Some tool operations (e.g., `pauseProject`, `restoreProject`, `deleteBranch`, etc.) currently return `Promise<void>`, providing no feedback to LLMs about whether operations succeeded. This causes LLM clients to think operations failed when they actually succeeded, leading to unnecessary retries and additional errors.

## Solution

- Created a `SuccessResponse` type: `{ success: true }`
- Updated all void operations to return `SuccessResponse` instead of `Promise<void>`
- Added a `SUCCESS_RESPONSE` constant with documentation explaining error handling behavior

## Affected Operations

**Account Operations:**
- `pauseProject`
- `restoreProject`

**Branching Operations:**
- `deleteBranch`
- `mergeBranch`
- `resetBranch`
- `rebaseBranch`

**Database Operations:**
- `applyMigration`

**Storage Operations:**
- `updateStorageConfig`

## Notes

- If an operation fails, `assertSuccess()` throws an error, so the success response only indicates successful completion
- This provides explicit confirmation to LLMs that operations completed successfully
- Follows the same pattern already used by some tools (e.g., storage config updates)

Fixes https://linear.app/supabase/issue/AI-164