### PR TITLE
feat: Add MCP elicitation for create project and branch tools

### DIFF
--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -234,10 +234,7 @@ export type DevelopmentOperations = {
 
 export type StorageOperations = {
   getStorageConfig(projectId: string): Promise<StorageConfig>;
-  updateStorageConfig(
-    projectId: string,
-    config: StorageConfig
-  ): Promise<void>;
+  updateStorageConfig(projectId: string, config: StorageConfig): Promise<void>;
   listAllBuckets(projectId: string): Promise<StorageBucket[]>;
 };
 
@@ -249,10 +246,7 @@ export type BranchingOperations = {
   ): Promise<Branch>;
   deleteBranch(branchId: string): Promise<void>;
   mergeBranch(branchId: string): Promise<void>;
-  resetBranch(
-    branchId: string,
-    options: ResetBranchOptions
-  ): Promise<void>;
+  resetBranch(branchId: string, options: ResetBranchOptions): Promise<void>;
   rebaseBranch(branchId: string): Promise<void>;
 };
 

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -144,6 +144,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
             database,
             projectId,
             readOnly,
+            server,
           })
         );
       }

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -134,7 +134,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       }
 
       if (!projectId && account && enabledFeatures.has('account')) {
-        Object.assign(tools, getAccountTools({ account, readOnly }));
+        Object.assign(tools, getAccountTools({ account, readOnly, server }));
       }
 
       if (database && enabledFeatures.has('database')) {

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -1,5 +1,6 @@
 import { tool, type ToolExecuteContext } from '@supabase/mcp-utils';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { ElicitResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import type { AccountOperations } from '../platform/types.js';
 import { type Cost, getBranchCost, getNextProjectCost } from '../pricing.js';
@@ -82,11 +83,16 @@ export function getAccountTools({
         return await account.getProject(id);
       },
     }),
-    get_cost: tool({
-      description:
-        'Gets the cost of creating a new project or branch. Never assume organization as costs can be different for each.',
+    get_and_confirm_cost: tool({
+      description: async () => {
+        const clientCapabilities = server?.getClientCapabilities();
+        if (clientCapabilities?.elicitation) {
+          return 'Gets the cost of creating a new project or branch and requests user confirmation. Returns a unique ID for this confirmation which must be passed to `create_project` or `create_branch`. Never assume organization as costs can be different for each.';
+        }
+        return 'Gets the cost of creating a new project or branch. You must repeat the cost to the user and confirm their understanding before calling `create_project` or `create_branch`. Returns a unique ID for this confirmation which must be passed to `create_project` or `create_branch`. Never assume organization as costs can be different for each.';
+      },
       annotations: {
-        title: 'Get cost of new resources',
+        title: 'Get and confirm cost',
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,
@@ -96,49 +102,94 @@ export function getAccountTools({
         type: z.enum(['project', 'branch']),
         organization_id: z
           .string()
-          .describe('The organization ID. Always ask the user.'),
+          .describe('The organization ID. Always ask the user.')
+          .optional(),
       }),
       execute: async ({ type, organization_id }) => {
-        function generateResponse(cost: Cost) {
-          return `The new ${type} will cost $${cost.amount} ${cost.recurrence}. You must repeat this to the user and confirm their understanding.`;
-        }
+        // Get the cost
+        let cost: Cost;
         switch (type) {
           case 'project': {
-            const cost = await getNextProjectCost(account, organization_id);
-            return generateResponse(cost);
+            if (!organization_id) {
+              throw new Error(
+                'organization_id is required for project cost calculation'
+              );
+            }
+            cost = await getNextProjectCost(account, organization_id);
+            break;
           }
           case 'branch': {
-            const cost = getBranchCost();
-            return generateResponse(cost);
+            cost = getBranchCost();
+            break;
           }
           default:
             throw new Error(`Unknown cost type: ${type}`);
         }
-      },
-    }),
-    confirm_cost: tool({
-      description:
-        'Ask the user to confirm their understanding of the cost of creating a new project or branch. Call `get_cost` first. Returns a unique ID for this confirmation which should be passed to `create_project` or `create_branch`.',
-      annotations: {
-        title: 'Confirm cost understanding',
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-        openWorldHint: false,
-      },
-      isSupported: (clientCapabilities) => !clientCapabilities?.elicitation,
-      parameters: z.object({
-        type: z.enum(['project', 'branch']),
-        recurrence: z.enum(['hourly', 'monthly']),
-        amount: z.number(),
-      }),
-      execute: async (cost) => {
-        return await hashObject(cost);
+
+        let userDeclinedCost = false;
+
+        // Request confirmation via elicitation if supported
+        const clientCapabilities = server?.getClientCapabilities();
+        if (server && clientCapabilities?.elicitation) {
+          try {
+            const costMessage =
+              cost.amount > 0 ? `$${cost.amount} ${cost.recurrence}` : 'Free';
+
+            const result = await server.request(
+              {
+                method: 'elicitation/create',
+                params: {
+                  message: `You are about to create a new ${type}.\n\nCost: ${costMessage}\n\nDo you want to proceed?`,
+                  requestedSchema: {
+                    type: 'object',
+                    properties: {
+                      confirm: {
+                        type: 'boolean',
+                        title: 'Confirm Cost',
+                        description: `I understand the cost and want to create the ${type}`,
+                      },
+                    },
+                    required: ['confirm'],
+                  },
+                },
+              },
+              ElicitResultSchema
+            );
+
+            if (result.action !== 'accept' || !result.content?.confirm) {
+              userDeclinedCost = true;
+            }
+          } catch (error) {
+            // If elicitation fails (client doesn't support it), return cost info for manual confirmation
+            console.warn(
+              'Elicitation not supported by client, returning cost for manual confirmation'
+            );
+            console.warn(error);
+          }
+        }
+
+        if (userDeclinedCost) {
+          throw new Error(
+            'The user declined to confirm the cost. Ask the user to confirm if they want to proceed with the operation or do something else.'
+          );
+        }
+
+        // Generate and return confirmation ID
+        const confirmationId = await hashObject(cost);
+
+        return {
+          ...cost,
+          confirm_cost_id: confirmationId,
+          message:
+            cost.amount > 0
+              ? `The new ${type} will cost $${cost.amount} ${cost.recurrence}. ${clientCapabilities?.elicitation ? 'User has confirmed.' : 'You must confirm this cost with the user before proceeding.'}`
+              : `The new ${type} is free. ${clientCapabilities?.elicitation ? 'User has confirmed.' : 'You may proceed with creation.'}`,
+        };
       },
     }),
     create_project: tool({
       description:
-        'Creates a new Supabase project. Always ask the user which organization to create the project in. If there is a cost involved, the user will be asked to confirm before creation. The project can take a few minutes to initialize - use `get_project` to check the status.',
+        'Creates a new Supabase project. Always ask the user which organization to create the project in. Call `get_and_confirm_cost` first to verify the cost and get user confirmation. The project can take a few minutes to initialize - use `get_project` to check the status.',
       annotations: {
         title: 'Create project',
         readOnlyHint: false,
@@ -152,47 +203,30 @@ export function getAccountTools({
           .enum(AWS_REGION_CODES)
           .describe('The region to create the project in.'),
         organization_id: z.string(),
+        confirm_cost_id: z
+          .string({
+            required_error:
+              'User must confirm understanding of costs before creating a project.',
+          })
+          .describe(
+            'The cost confirmation ID. Call `get_and_confirm_cost` first.'
+          ),
       }),
-      execute: async ({ name, region, organization_id }, context) => {
+      execute: async ({ name, region, organization_id, confirm_cost_id }) => {
         if (readOnly) {
           throw new Error('Cannot create a project in read-only mode.');
         }
 
-        // Calculate cost inline
+        // Verify the confirmation ID matches the expected cost
         const cost = await getNextProjectCost(account, organization_id);
-
-        // Only request confirmation if there's a cost AND server supports elicitation
-        if (cost.amount > 0 && context?.server?.elicitInput) {
-          const costMessage = `$${cost.amount} per ${cost.recurrence}`;
-
-          const result = await context.server.elicitInput({
-            message: `You are about to create project "${name}" in region ${region}.\n\n💰 Cost: ${costMessage}\n\nDo you want to proceed with this billable project?`,
-            requestedSchema: {
-              type: 'object',
-              properties: {
-                confirm: {
-                  type: 'boolean',
-                  title: 'Confirm billable project creation',
-                  description: `I understand this will cost ${costMessage} and want to proceed`,
-                },
-              },
-              required: ['confirm'],
-            },
-          });
-
-          // Handle user response
-          if (result.action === 'decline' || result.action === 'cancel') {
-            throw new Error('Project creation cancelled by user.');
-          }
-
-          if (result.action === 'accept' && !result.content?.confirm) {
-            throw new Error(
-              'You must confirm understanding of the cost to create a billable project.'
-            );
-          }
+        const costHash = await hashObject(cost);
+        if (costHash !== confirm_cost_id) {
+          throw new Error(
+            'Cost confirmation ID does not match the expected cost of creating a project.'
+          );
         }
 
-        // Create the project (either free or confirmed)
+        // Create the project
         const project = await account.createProject({
           name,
           region,

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -126,6 +126,7 @@ export function getAccountTools({
         idempotentHint: true,
         openWorldHint: false,
       },
+      isSupported: (clientCapabilities) => !clientCapabilities?.elicitation,
       parameters: z.object({
         type: z.enum(['project', 'branch']),
         recurrence: z.enum(['hourly', 'monthly']),

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -232,7 +232,8 @@ export function getDatabaseTools({
                       confirm: {
                         type: 'boolean',
                         title: 'Confirm Migration',
-                        description: 'I have reviewed the SQL and approve this migration',
+                        description:
+                          'I have reviewed the SQL and approve this migration',
                       },
                     },
                     required: ['confirm'],

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -1,5 +1,6 @@
 import { source } from 'common-tags';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { ElicitResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import { listExtensionsSql, listTablesSql } from '../pg-meta/index.js';
 import {
@@ -221,7 +222,7 @@ export function getDatabaseTools({
         // Try to request user confirmation via elicitation
         if (server) {
           try {
-            const result = (await server.request(
+            const result = await server.request(
               {
                 method: 'elicitation/create',
                 params: {
@@ -240,12 +241,8 @@ export function getDatabaseTools({
                   },
                 },
               },
-              // @ts-ignore - elicitation types might not be available
-              { elicitation: true }
-            )) as {
-              action: 'accept' | 'decline' | 'cancel';
-              content?: { confirm?: boolean };
-            };
+              ElicitResultSchema
+            );
 
             // User declined or cancelled
             if (result.action !== 'accept' || !result.content?.confirm) {

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -1,4 +1,5 @@
 import { source } from 'common-tags';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { z } from 'zod';
 import { listExtensionsSql, listTablesSql } from '../pg-meta/index.js';
 import {
@@ -14,12 +15,14 @@ export type DatabaseOperationToolsOptions = {
   database: DatabaseOperations;
   projectId?: string;
   readOnly?: boolean;
+  server?: Server;
 };
 
 export function getDatabaseTools({
   database,
   projectId,
   readOnly,
+  server,
 }: DatabaseOperationToolsOptions) {
   const project_id = projectId;
 
@@ -213,6 +216,47 @@ export function getDatabaseTools({
       execute: async ({ project_id, name, query }) => {
         if (readOnly) {
           throw new Error('Cannot apply migration in read-only mode.');
+        }
+
+        // Try to request user confirmation via elicitation
+        if (server) {
+          try {
+            const result = (await server.request(
+              {
+                method: 'elicitation/create',
+                params: {
+                  message: `You are about to apply migration "${name}" to project ${project_id}. This will modify your database schema.\n\nPlease review the SQL:\n\n${query}\n\nDo you want to proceed?`,
+                  requestedSchema: {
+                    type: 'object',
+                    properties: {
+                      confirm: {
+                        type: 'boolean',
+                        title: 'Confirm Migration',
+                        description: 'I have reviewed the SQL and approve this migration',
+                      },
+                    },
+                    required: ['confirm'],
+                  },
+                },
+              },
+              // @ts-ignore - elicitation types might not be available
+              { elicitation: true }
+            )) as {
+              action: 'accept' | 'decline' | 'cancel';
+              content?: { confirm?: boolean };
+            };
+
+            // User declined or cancelled
+            if (result.action !== 'accept' || !result.content?.confirm) {
+              throw new Error('Migration cancelled by user');
+            }
+          } catch (error) {
+            // If elicitation fails (client doesn't support it), proceed without confirmation
+            // This maintains backwards compatibility
+            console.warn(
+              'Elicitation not supported by client, proceeding with migration without confirmation'
+            );
+          }
         }
 
         await database.applyMigration(project_id, {

--- a/packages/mcp-server-supabase/src/tools/util.ts
+++ b/packages/mcp-server-supabase/src/tools/util.ts
@@ -64,6 +64,6 @@ export function injectableTool<
     description,
     annotations,
     parameters: parameters.omit(mask),
-    execute: (args) => execute({ ...args, ...inject }),
+    execute: (args, context) => execute({ ...args, ...inject }, context),
   }) as Tool<z.ZodObject<any, any, any, CleanParams>, Result>;
 }

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -61,6 +61,17 @@ export type Tool<
   description: Prop<string>;
   annotations?: Annotations;
   parameters: Params;
+  /**
+   * Optional predicate to determine if this tool should be listed/usable for the
+   * connected client based on its declared capabilities. If omitted, the tool
+   * is assumed to be supported by all clients.
+   *
+   * Example: Only show when the client supports elicitation
+   *  isSupported: (caps) => Boolean(caps?.elicitation)
+   */
+  isSupported?: (
+    clientCapabilities: ClientCapabilities | undefined
+  ) => boolean | Promise<boolean>;
   execute(
     params: z.infer<Params>,
     context?: ToolExecuteContext
@@ -443,28 +454,41 @@ export function createMcpServer(options: McpServerOptions) {
       ListToolsRequestSchema,
       async (): Promise<ListToolsResult> => {
         const tools = await getTools();
+        const clientCapabilities = server.getClientCapabilities();
+
+        // Filter tools based on client capabilities when a predicate is provided
+        const supportedToolEntries = (
+          await Promise.all(
+            Object.entries(tools).map(async ([name, tool]) => {
+              const ok =
+                typeof tool.isSupported === 'function'
+                  ? await tool.isSupported(clientCapabilities)
+                  : true;
+              return ok ? ([name, tool] as const) : null;
+            })
+          )
+        ).filter(Boolean) as Array<readonly [string, Tool]>;
 
         return {
           tools: await Promise.all(
-            Object.entries(tools).map(
-              async ([name, { description, annotations, parameters }]) => {
-                const inputSchema = zodToJsonSchema(parameters);
+            supportedToolEntries.map(async ([name, tool]) => {
+              const { description, annotations, parameters } = tool;
+              const inputSchema = zodToJsonSchema(parameters);
 
-                if (!('properties' in inputSchema)) {
-                  throw new Error('tool parameters must be a ZodObject');
-                }
-
-                return {
-                  name,
-                  description:
-                    typeof description === 'function'
-                      ? await description()
-                      : description,
-                  annotations,
-                  inputSchema,
-                };
+              if (!('properties' in inputSchema)) {
+                throw new Error('tool parameters must be a ZodObject');
               }
-            )
+
+              return {
+                name,
+                description:
+                  typeof description === 'function'
+                    ? await description()
+                    : description,
+                annotations,
+                inputSchema,
+              };
+            })
           ),
         } satisfies ListToolsResult;
       }

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -50,6 +50,10 @@ export type ResourceTemplate<Uri extends string = string, Result = unknown> = {
   ): Promise<Result>;
 };
 
+export type ToolExecuteContext = {
+  server?: Server;
+};
+
 export type Tool<
   Params extends z.ZodObject<any> = z.ZodObject<any>,
   Result = unknown,
@@ -57,7 +61,10 @@ export type Tool<
   description: Prop<string>;
   annotations?: Annotations;
   parameters: Params;
-  execute(params: z.infer<Params>): Promise<Result>;
+  execute(
+    params: z.infer<Params>,
+    context?: ToolExecuteContext
+  ): Promise<Result>;
 };
 
 /**
@@ -484,7 +491,7 @@ export function createMcpServer(options: McpServerOptions) {
         const executeWithCallback = async (tool: Tool) => {
           // Wrap success or error in a result value
           const res = await tool
-            .execute(args)
+            .execute(args, { server })
             .then((data: unknown) => ({ success: true as const, data }))
             .catch((error) => ({ success: false as const, error }));
 


### PR DESCRIPTION
## Summary

Implements MCP elicitation for the `apply_migration` tool to request user confirmation before applying database migrations.

## Implementation

Uses a try-catch pattern to gracefully fallback when clients don't support elicitation:
- **Supporting clients**: Show confirmation dialog with migration details and SQL preview
- **Non-supporting clients**: Proceed with migration without confirmation (existing behavior)

## Client Support

Currently supported: VS Code Copilot, Cursor, Postman, VT Code, fast-agent, mcp-use, MCPJam

Not yet supported: Claude Desktop, Claude.ai, GitHub Copilot coding agent

## Related

[AI-142: Explore MCP Elicitations](https://linear.app/supabase/issue/AI-142)