### PR TITLE
v0.5.8

### DIFF
--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supabase/mcp-server-supabase",
   "mcpName": "com.supabase/mcp",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "MCP server for interacting with Supabase",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/mcp-server-supabase/server.json
+++ b/packages/mcp-server-supabase/server.json
@@ -8,7 +8,7 @@
     "subfolder": "packages/mcp-server-supabase"
   },
   "websiteUrl": "https://supabase.com/mcp",
-  "version": "0.5.6",
+  "version": "0.5.8",
   "remotes": [
     {
       "type": "streamable-http",
@@ -20,7 +20,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@supabase/mcp-server-supabase",
-      "version": "0.5.6",
+      "version": "0.5.8",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bump version `v0.5.8` (already [released to npmjs](https://www.npmjs.com/package/@supabase/mcp-server-supabase/v/0.5.8))

Resolves AI-139