### PR TITLE
chore: bump registry schema to `2025-10-17`

### DIFF
--- a/packages/mcp-server-supabase/server.json
+++ b/packages/mcp-server-supabase/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "com.supabase/mcp",
   "description": "MCP server for interacting with the Supabase platform",
   "repository": {


### PR DESCRIPTION
Fixes `pnpm registry:publish`, also needed to update `mcp-publisher` to latest (I'm running `1.3.8`)