### PR TITLE
docs: add Factory client installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ For more information, see the [VS Code MCP docs](https://code.visualstudio.com/d
 
 </details>
 
+<details>
+<summary>Factory</summary>
+
+#### Install via command line:
+
+```bash
+droid mcp add supabase https://mcp.supabase.com/mcp --type http
+```
+
+#### Or install manually:
+
+Open (or create) your `~/.factory/mcp.json` file and add:
+
+```json
+{
+  "supabase": {
+    "type": "http",
+    "url": "https://mcp.supabase.com/mcp"
+  }
+}
+```
+
+After adding the server, restart Factory or type `/mcp` within droid to complete the OAuth authentication flow.
+
+For more information, see the [Factory MCP docs](https://docs.factory.ai/cli/configuration/mcp.md).
+
+</details>
+
 ## Options
 
 The following options are configurable as URL query parameters:


### PR DESCRIPTION
This PR adds installation instructions for using the Supabase MCP server with Factory (https://factory.ai), an AI coding assistant.

Factory supports MCP HTTP servers and can connect to the Supabase MCP server using either the CLI command or manual configuration.

The documentation section follows the same format as existing clients (Cursor and VS Code) and includes:
- CLI installation command using `droid mcp add`
- Manual configuration instructions for `~/.factory/mcp.json`
- Link to Factory's MCP documentation

This addition helps Factory users easily discover and connect to the Supabase MCP server.