### PR TITLE
chore(registry): add title and icon to server.json

### DIFF
--- a/packages/mcp-server-supabase/server.json
+++ b/packages/mcp-server-supabase/server.json
@@ -1,7 +1,45 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "com.supabase/mcp",
+  "title": "Supabase",
   "description": "MCP server for interacting with the Supabase platform",
+  "icons": [
+    {
+      "mimeType": "image/png",
+      "sizes": ["16x16"],
+      "src": "https://supabase.com/favicon/favicon-16x16.png"
+    },
+    {
+      "mimeType": "image/png",
+      "sizes": ["32x32"],
+      "src": "https://supabase.com/favicon/favicon-32x32.png"
+    },
+    {
+      "mimeType": "image/png",
+      "sizes": ["48x48"],
+      "src": "https://supabase.com/favicon/favicon-48x48.png"
+    },
+    {
+      "mimeType": "image/png",
+      "sizes": ["96x96"],
+      "src": "https://supabase.com/favicon/favicon-96x96.png"
+    },
+    {
+      "mimeType": "image/png",
+      "sizes": ["128x128"],
+      "src": "https://supabase.com/favicon/favicon-128.png"
+    },
+    {
+      "mimeType": "image/png",
+      "sizes": ["180x180"],
+      "src": "https://supabase.com/favicon/favicon-180x180.png"
+    },
+    {
+      "mimeType": "image/png",
+      "sizes": ["196x196"],
+      "src": "https://supabase.com/favicon/favicon-196x196.png"
+    }
+  ],
   "repository": {
     "url": "https://github.com/supabase-community/supabase-mcp",
     "source": "github",


### PR DESCRIPTION
Adds `title` and `icons` to MCP registry `server.json` file.

Likely `title` will fix our MCP server's name listed in GitHub's MCP registry:
<img width="2618" height="1230" alt="image" src="https://github.com/user-attachments/assets/102f3888-c394-4526-ae87-1539d0f9c3b3" />
_I cross referenced other repos like [Stripe](https://github.com/stripe/ai/blob/28573dfbc3c5e4c32d37146d9afc6806e1b5f4a1/tools/modelcontextprotocol/server.json#L3) and [Context7](https://github.com/upstash/context7/blob/81cfa22752e8d63e980a66a0c8cc5357bcf3b09c/server.json#L4), and the difference in name also came down to whether or not `title` was set._