### PR TITLE
feat: rls prompting on apply_migration tool

### DIFF
--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -196,7 +196,7 @@ export function getDatabaseTools({
     }),
     apply_migration: injectableTool({
       description:
-        'Applies a migration to the database. Use this when executing DDL operations. Do not hardcode references to generated IDs in data migrations.',
+        'Applies a migration to the database. Use this when executing DDL operations. RLS must be enabled on all tables and include policies (consult docs for best practices). Do not hardcode references to generated IDs in data migrations.',
       annotations: {
         title: 'Apply migration',
         readOnlyHint: false,


### PR DESCRIPTION
To help prevent developers from shooting themselves in the foot (exposing tables publicly via PostgREST), let's encourage the LLM to always enable RLS on any table.