### PR TITLE
Add Dockerfile for Supabase MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Use a slim Node.js base image
+FROM node:20-slim
+
+# Enable pnpm via corepack
+RUN corepack enable
+
+# Set working directory
+WORKDIR /app
+
+# Copy root workspace files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Copy only the required packages
+COPY packages/mcp-utils ./packages/mcp-utils
+COPY packages/mcp-server-supabase ./packages/mcp-server-supabase
+
+# Install dependencies without running scripts
+RUN pnpm install --frozen-lockfile --ignore-scripts
+
+# Build mcp-utils
+WORKDIR /app/packages/mcp-utils
+RUN pnpm exec tsup --no-dts
+
+# Build mcp-server-supabase
+WORKDIR /app/packages/mcp-server-supabase
+RUN pnpm exec tsup --no-dts
+
+# Default command: run the MCP server over stdio
+CMD ["node", "dist/index.js"]
+


### PR DESCRIPTION
## Summary
Adds a Dockerfile to allow running the Supabase MCP server via Docker.

## Why
This enables:
- Easier local usage
- Compatibility with Docker-based MCP registries
- Consistent runtime setup for users and tooling

## Notes
- Uses Node 20 slim
- Builds `@supabase/mcp-utils` and `@supabase/mcp-server-supabase`
- Runs via stdio transport (MCP-compatible)

No breaking changes.
