### PR TITLE
docs: add AI guidance files (AGENTS.md, CLAUDE.md, Skills)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,120 +1,46 @@
 # AGENTS.md
 
-This file provides guidance for AI agents working on this codebase.
+This file provides guidance to AI coding agents working on this repository.
 
 ## Project Overview
 
-Supabase MCP (Model Context Protocol) servers - a pnpm monorepo with:
-- `packages/mcp-utils` - Shared utilities
-- `packages/mcp-server-supabase` - Main MCP server
-- `packages/mcp-server-postgrest` - PostgREST MCP server
+Supabase MCP (Model Context Protocol) servers - a pnpm monorepo.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `@supabase/mcp-utils` | Shared utilities and base classes for MCP servers |
+| `@supabase/mcp-server-supabase` | Main MCP server for Supabase platform |
+| `@supabase/mcp-server-postgrest` | PostgREST MCP server |
+
+## Build & Test Commands
+
+```sh
+pnpm install    # Install all workspace dependencies
+pnpm build      # Build mcp-utils and mcp-server-supabase
+pnpm test       # Run all tests in parallel
+pnpm test:coverage
+pnpm format     # Fix formatting with Biome
+pnpm format:check
+```
+
+## Package Manager
+
+This repo uses **pnpm** exclusively. Do not use npm or yarn.
+
+## Dev Dependencies
+
+- `@biomejs/biome` - Code formatting
+- `supabase` - Supabase CLI
 
 ## Package-Specific Guides
 
-For detailed package-specific guidance, see:
 - [packages/mcp-utils/AGENTS.md](packages/mcp-utils/AGENTS.md)
 - [packages/mcp-server-supabase/AGENTS.md](packages/mcp-server-supabase/AGENTS.md)
 
-## Development Environment
-
-### Prerequisites
-
-Install [mise](https://mise.jdx.dev/) for tool version management.
-
-### Setup
-
-```bash
-mise install    # Install Node.js and pnpm (versions from mise.toml)
-pnpm install    # Install dependencies
-```
-
-### Development Mode
-
-```bash
-cd packages/mcp-server-supabase
-pnpm dev        # Watch mode with auto-rebuild
-```
-
-**Important:** Always use `pnpm dev` while iterating. Do NOT run `pnpm build` during development - it's slow and unnecessary. The `prebuild` hook runs `typecheck` automatically.
-
-## Commands Reference
-
-### Build
-
-| Command | Description |
-|---------|-------------|
-| `pnpm build` | Build mcp-utils and mcp-server-supabase (production only) |
-| `pnpm dev` | Watch mode (run from package directory) |
-| `pnpm typecheck` | Type check without emitting (run from package directory) |
-
-### Test
-
-| Command | Description |
-|---------|-------------|
-| `pnpm test` | Run all tests in parallel |
-| `pnpm test:unit` | Unit tests only (mcp-server-supabase) |
-| `pnpm test:e2e` | E2E tests only (requires `SUPABASE_ACCESS_TOKEN`) |
-| `pnpm test:integration` | Integration tests only |
-| `pnpm test:coverage` | Tests with coverage report |
-
-### Code Style
-
-| Command | Description |
-|---------|-------------|
-| `pnpm format` | Auto-fix formatting issues |
-| `pnpm format:check` | Check formatting (used in CI) |
-
-## Code Style Guidelines
-
-- **Formatter**: Biome (linting disabled, formatting only)
-- **Quotes**: Single quotes
-- **Trailing commas**: ES5 style
-- **Indentation**: Spaces
-- **Semicolons**: Required
-
-## Testing Patterns
-
-### File Naming
-- Unit tests: `*.test.ts` (co-located in `src/`)
-- E2E tests: `*.e2e.ts` (in `test/e2e/`)
-- Integration tests: `*.integration.ts`
-
-### Test Infrastructure
-- **HTTP mocking**: MSW (Mock Service Worker)
-- **Database**: PGlite (in-memory PostgreSQL)
-- **Test timeout**: 30s default, 60s for E2E
-
-## PR Checklist
-
-Before submitting a PR, run:
-
-```bash
-pnpm format       # Fix formatting
-pnpm build        # Ensure it compiles
-pnpm test         # Run all tests
-```
-
-### CI Checks (must pass)
-1. **Biome** - Code formatting
-2. **Tests** - All test suites with coverage
-
 ## Do NOT
 
-- Edit `packages/mcp-server-supabase/src/management-api/types.ts` - auto-generated from OpenAPI
-- Modify `mise.lock` or `pnpm-lock.yaml` manually - managed by tools
 - Use `npm` or `yarn` - this repo uses pnpm only
-- Skip type checking - `prebuild` runs `tsc --noEmit`
-- Ignore Biome formatting - CI will fail
-- Commit `dist/` files - they're gitignored
-- Commit `.env.local` or other sensitive files
-- Run `pnpm build` during interactive agent sessions - use `pnpm dev` instead
-
-## Keeping AGENTS.md Up to Date
-
-Update this file when you change:
-- Dependencies in `package.json` or `pnpm-lock.yaml`
-- Scripts in `package.json` files
-- Tool versions in `mise.toml`
-- Test configuration in `vitest.config.ts`
-- CI workflows in `.github/workflows/`
-- Code style rules in `biome.json`
+- Modify `mise.lock` or `pnpm-lock.yaml` manually
+- Run `pnpm build` during dev sessions - use `pnpm dev` in package directories

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,120 @@
-# AGENTS Guidelines for This Repository
+# AGENTS.md
 
-This repository is a monorepo containing MCP (Model Context Protocol) servers for Supabase.
-When working on this project interactively with an agent, please follow the guidelines below.
+This file provides guidance for AI agents working on this codebase.
 
-## 1. Use Development Mode, **not** Production Builds
+## Project Overview
 
-* **Always use `pnpm dev`** while iterating on packages. Navigate to the package directory first:
-  ```bash
-  cd packages/mcp-server-supabase && pnpm dev
-  ```
-  This starts tsup in watch mode with hot-reload enabled.
+Supabase MCP (Model Context Protocol) servers - a pnpm monorepo with:
+- `packages/mcp-utils` - Shared utilities
+- `packages/mcp-server-supabase` - Main MCP server
+- `packages/mcp-server-postgrest` - PostgREST MCP server
 
-* **Do _not_ run `pnpm build` inside the agent session.** Running the production build
-  command is slow and unnecessary during development. The `prebuild` hook runs
-  `typecheck` automatically, so type errors will fail builds anyway. If a production
-  build is required, do it outside of the interactive agent workflow.
+## Package-Specific Guides
 
-## 2. Keep Dependencies in Sync
+For detailed package-specific guidance, see:
+- [packages/mcp-utils/AGENTS.md](packages/mcp-utils/AGENTS.md)
+- [packages/mcp-server-supabase/AGENTS.md](packages/mcp-server-supabase/AGENTS.md)
 
-If you add or update dependencies:
+## Development Environment
 
-1. Update the lockfile (`pnpm-lock.yaml`) - pnpm handles this automatically.
-2. Re-start the development server if it's running so changes are picked up.
+### Prerequisites
 
-## 3. Run Tests Before Committing
+Install [mise](https://mise.jdx.dev/) for tool version management.
 
-* Run `pnpm test` from the repository root to test all packages.
-* For package-specific tests: `cd packages/mcp-server-supabase && pnpm test:unit`
-* E2E tests require `SUPABASE_ACCESS_TOKEN` environment variable.
+### Setup
 
-## 4. Format Code Before Committing
+```bash
+mise install    # Install Node.js and pnpm (versions from mise.toml)
+pnpm install    # Install dependencies
+```
 
-* Always run `pnpm format` from the repository root before committing.
-* Formatting is checked in CI - unformatted code will fail PR checks.
+### Development Mode
 
-## 5. Useful Commands
+```bash
+cd packages/mcp-server-supabase
+pnpm dev        # Watch mode with auto-rebuild
+```
 
-| Command | Purpose |
-|---------|---------|
-| `pnpm install` | Install dependencies (from repo root) |
-| `cd packages/mcp-server-supabase && pnpm dev` | **Start dev server with watch mode** |
-| `cd packages/mcp-server-supabase && pnpm typecheck` | Type check without emitting files |
-| `pnpm test` | Run all tests |
-| `pnpm format` | Format all files with Biome |
-| `pnpm build` | **Production build – _do not run during agent sessions_** |
+**Important:** Always use `pnpm dev` while iterating. Do NOT run `pnpm build` during development - it's slow and unnecessary. The `prebuild` hook runs `typecheck` automatically.
 
-## 6. What NOT to Commit
+## Commands Reference
 
-* Do NOT commit `dist/` files (they're gitignored)
-* Do NOT commit `.env.local` or other sensitive files
-* Do NOT modify `pnpm-lock.yaml` manually - let pnpm manage it
+### Build
 
----
+| Command | Description |
+|---------|-------------|
+| `pnpm build` | Build mcp-utils and mcp-server-supabase (production only) |
+| `pnpm dev` | Watch mode (run from package directory) |
+| `pnpm typecheck` | Type check without emitting (run from package directory) |
 
-**Tech Stack:** Node.js 22.18.0, pnpm 10.15.0, TypeScript, Vitest, Biome, tsup
+### Test
 
-**Packages:**
-- `@supabase/mcp-server-supabase` - Main Supabase MCP server
-- `@supabase/mcp-server-postgrest` - PostgREST MCP server
-- `@supabase/mcp-utils` - Shared utilities
+| Command | Description |
+|---------|-------------|
+| `pnpm test` | Run all tests in parallel |
+| `pnpm test:unit` | Unit tests only (mcp-server-supabase) |
+| `pnpm test:e2e` | E2E tests only (requires `SUPABASE_ACCESS_TOKEN`) |
+| `pnpm test:integration` | Integration tests only |
+| `pnpm test:coverage` | Tests with coverage report |
 
-Following these practices ensures that the agent-assisted development workflow stays fast and
-dependable. When in doubt, restart the dev server rather than running the production build.
+### Code Style
+
+| Command | Description |
+|---------|-------------|
+| `pnpm format` | Auto-fix formatting issues |
+| `pnpm format:check` | Check formatting (used in CI) |
+
+## Code Style Guidelines
+
+- **Formatter**: Biome (linting disabled, formatting only)
+- **Quotes**: Single quotes
+- **Trailing commas**: ES5 style
+- **Indentation**: Spaces
+- **Semicolons**: Required
+
+## Testing Patterns
+
+### File Naming
+- Unit tests: `*.test.ts` (co-located in `src/`)
+- E2E tests: `*.e2e.ts` (in `test/e2e/`)
+- Integration tests: `*.integration.ts`
+
+### Test Infrastructure
+- **HTTP mocking**: MSW (Mock Service Worker)
+- **Database**: PGlite (in-memory PostgreSQL)
+- **Test timeout**: 30s default, 60s for E2E
+
+## PR Checklist
+
+Before submitting a PR, run:
+
+```bash
+pnpm format       # Fix formatting
+pnpm build        # Ensure it compiles
+pnpm test         # Run all tests
+```
+
+### CI Checks (must pass)
+1. **Biome** - Code formatting
+2. **Tests** - All test suites with coverage
+
+## Do NOT
+
+- Edit `packages/mcp-server-supabase/src/management-api/types.ts` - auto-generated from OpenAPI
+- Modify `mise.lock` or `pnpm-lock.yaml` manually - managed by tools
+- Use `npm` or `yarn` - this repo uses pnpm only
+- Skip type checking - `prebuild` runs `tsc --noEmit`
+- Ignore Biome formatting - CI will fail
+- Commit `dist/` files - they're gitignored
+- Commit `.env.local` or other sensitive files
+- Run `pnpm build` during interactive agent sessions - use `pnpm dev` instead
+
+## Keeping AGENTS.md Up to Date
+
+Update this file when you change:
+- Dependencies in `package.json` or `pnpm-lock.yaml`
+- Scripts in `package.json` files
+- Tool versions in `mise.toml`
+- Test configuration in `vitest.config.ts`
+- CI workflows in `.github/workflows/`
+- Code style rules in `biome.json`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS Guidelines for This Repository
+
+This repository is a monorepo containing MCP (Model Context Protocol) servers for Supabase.
+When working on this project interactively with an agent, please follow the guidelines below.
+
+## 1. Use Development Mode, **not** Production Builds
+
+* **Always use `pnpm dev`** while iterating on packages. Navigate to the package directory first:
+  ```bash
+  cd packages/mcp-server-supabase && pnpm dev
+  ```
+  This starts tsup in watch mode with hot-reload enabled.
+
+* **Do _not_ run `pnpm build` inside the agent session.** Running the production build
+  command is slow and unnecessary during development. The `prebuild` hook runs
+  `typecheck` automatically, so type errors will fail builds anyway. If a production
+  build is required, do it outside of the interactive agent workflow.
+
+## 2. Keep Dependencies in Sync
+
+If you add or update dependencies:
+
+1. Update the lockfile (`pnpm-lock.yaml`) - pnpm handles this automatically.
+2. Re-start the development server if it's running so changes are picked up.
+
+## 3. Run Tests Before Committing
+
+* Run `pnpm test` from the repository root to test all packages.
+* For package-specific tests: `cd packages/mcp-server-supabase && pnpm test:unit`
+* E2E tests require `SUPABASE_ACCESS_TOKEN` environment variable.
+
+## 4. Format Code Before Committing
+
+* Always run `pnpm format` from the repository root before committing.
+* Formatting is checked in CI - unformatted code will fail PR checks.
+
+## 5. Useful Commands
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm install` | Install dependencies (from repo root) |
+| `cd packages/mcp-server-supabase && pnpm dev` | **Start dev server with watch mode** |
+| `cd packages/mcp-server-supabase && pnpm typecheck` | Type check without emitting files |
+| `pnpm test` | Run all tests |
+| `pnpm format` | Format all files with Biome |
+| `pnpm build` | **Production build – _do not run during agent sessions_** |
+
+## 6. What NOT to Commit
+
+* Do NOT commit `dist/` files (they're gitignored)
+* Do NOT commit `.env.local` or other sensitive files
+* Do NOT modify `pnpm-lock.yaml` manually - let pnpm manage it
+
+---
+
+**Tech Stack:** Node.js 22.18.0, pnpm 10.15.0, TypeScript, Vitest, Biome, tsup
+
+**Packages:**
+- `@supabase/mcp-server-supabase` - Main Supabase MCP server
+- `@supabase/mcp-server-postgrest` - PostgREST MCP server
+- `@supabase/mcp-utils` - Shared utilities
+
+Following these practices ensures that the agent-assisted development workflow stays fast and
+dependable. When in doubt, restart the dev server rather than running the production build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](./AGENTS.md) for project guidelines.

--- a/packages/mcp-server-supabase/.claude/skills/architecture/SKILL.md
+++ b/packages/mcp-server-supabase/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: mcp-server-supabase-architecture
+description: Source structure, core layers, and data flow for the Supabase MCP server. Use when modifying the server structure, adding new tool domains, or understanding how components connect.
+---
+
+# Architecture Overview
+
+## Source Structure
+
+```
+src/
+├── server.ts                 # Main factory: createSupabaseMcpServer()
+├── index.ts                  # Public exports
+├── types.ts                  # Shared Zod schemas
+├── tools/                    # MCP tool implementations by domain
+│   ├── account-tools.ts      # list_organizations, get_project, create_project
+│   ├── database-operation-tools.ts  # execute_sql, list_tables
+│   ├── edge-function-tools.ts       # deploy_edge_function
+│   ├── storage-tools.ts
+│   ├── branching-tools.ts
+│   ├── debugging-tools.ts
+│   ├── development-tools.ts
+│   └── docs-tools.ts
+├── management-api/           # Supabase Management API client
+│   ├── index.ts              # Client factory (openapi-fetch)
+│   └── types.ts              # AUTO-GENERATED - do not edit
+├── content-api/              # Documentation GraphQL API
+├── pg-meta/                  # Database introspection SQL generators
+├── platform/                 # Platform abstraction layer
+│   ├── types.ts              # Operation interfaces
+│   └── api-platform.ts       # Management API implementation
+└── transports/
+    └── stdio.ts              # CLI entry point
+```
+
+## Core Layers
+
+1. **Server Layer** (`server.ts`) - MCP server factory, feature orchestration
+2. **Tools Layer** (`tools/`) - Domain-grouped implementations using `tool()` helper
+3. **Platform Layer** (`platform/`) - Abstraction over Supabase APIs
+4. **API Clients** - Management API (openapi-fetch), Content API (GraphQL)
+
+## Data Flow
+
+```
+AI Client → Stdio Transport → MCP Server → Tool Handler → Platform Operations → Supabase API
+```
+
+## Adding a New Tool Domain
+
+1. Create `src/tools/new-domain-tools.ts`
+2. Export `getNewDomainTools({ operations, readOnly })` function
+3. Add operation interface to `platform/types.ts`
+4. Implement operations in `platform/api-platform.ts`
+5. Register in `server.ts` conditional tool loading

--- a/packages/mcp-server-supabase/.claude/skills/testing/SKILL.md
+++ b/packages/mcp-server-supabase/.claude/skills/testing/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: mcp-server-supabase-testing
+description: Testing patterns for the Supabase MCP server including MSW HTTP mocking, PGlite database mocking, and AI-powered assertions. Use when writing tests, setting up mocks, or debugging test failures.
+---
+
+# Testing Patterns
+
+## Test Types
+
+- **Unit**: `src/**/*.test.ts` - Co-located with source
+- **E2E**: `test/e2e/**/*.e2e.ts` - Requires `SUPABASE_ACCESS_TOKEN`
+- **Integration**: `test/**/*.integration.ts`
+
+## HTTP Mocking with MSW
+
+All unit tests MUST mock HTTP calls using MSW. Mocks are defined in `test/mocks.ts`.
+
+```typescript
+import { setupServer } from 'msw/node';
+import { mockManagementApi } from './mocks.ts';
+
+const server = setupServer(...mockManagementApi);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+beforeEach(() => {
+  mockOrgs.clear();
+  mockProjects.clear();
+});
+afterAll(() => server.close());
+```
+
+## Database Mocking with PGlite
+
+```typescript
+import { PGlite } from '@electric-sql/pglite';
+
+const db = new PGlite();
+await db.waitReady;
+await db.exec(`
+  CREATE ROLE supabase_read_only_role;
+  GRANT pg_read_all_data TO supabase_read_only_role;
+`);
+```
+
+## AI Test Matcher
+
+Custom `toMatchCriteria()` uses Claude API for semantic assertions:
+
+```typescript
+// Requires ANTHROPIC_API_KEY
+await expect(response.text).toMatchCriteria('Contains a valid SQL query');
+```
+
+## Test Setup Pattern
+
+```typescript
+async function setup(options = {}) {
+  const clientTransport = new StreamTransport();
+  const serverTransport = new StreamTransport();
+
+  clientTransport.readable.pipeTo(serverTransport.writable);
+  serverTransport.readable.pipeTo(clientTransport.writable);
+
+  const client = new Client({ name: 'test', version: '1.0' }, { capabilities: {} });
+  const platform = createSupabaseApiPlatform({ apiUrl, accessToken });
+  const server = createSupabaseMcpServer({ platform, ...options });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server };
+}
+```

--- a/packages/mcp-server-supabase/.claude/skills/tool-registration/SKILL.md
+++ b/packages/mcp-server-supabase/.claude/skills/tool-registration/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mcp-server-supabase-tools
+description: Tool registration patterns for the Supabase MCP server. Use when creating new tools, modifying existing tools, or understanding how tools are registered with the server.
+---
+
+# Tool Registration Patterns
+
+## Creating Tools
+
+Tools use the `tool()` helper from `@supabase/mcp-utils`:
+
+```typescript
+import { tool } from '@supabase/mcp-utils';
+import { z } from 'zod';
+
+export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
+  return {
+    list_organizations: tool({
+      description: 'Lists all organizations the user is a member of.',
+      annotations: {
+        title: 'List organizations',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      parameters: z.object({}),
+      execute: async () => account.listOrganizations(),
+    }),
+
+    create_project: tool({
+      description: 'Creates a new Supabase project.',
+      annotations: {
+        title: 'Create project',
+        readOnlyHint: false,
+        destructiveHint: false,
+      },
+      parameters: z.object({
+        name: z.string(),
+        organization_id: z.string(),
+        region: z.enum(AWS_REGION_CODES),
+      }),
+      execute: async (params) => account.createProject(params),
+    }),
+  };
+}
+```
+
+## Tool Annotations
+
+- `readOnlyHint`: Tool doesn't modify state
+- `destructiveHint`: Tool may delete/corrupt data
+- `idempotentHint`: Calling multiple times has same effect
+- `openWorldHint`: Tool interacts with external world
+
+## Registering Tools in Server
+
+Tools are conditionally registered in `server.ts`:
+
+```typescript
+const server = createMcpServer({
+  name: 'supabase',
+  tools: async () => {
+    const tools: Record<string, Tool> = {};
+
+    if (enabledFeatures.has('account') && account) {
+      Object.assign(tools, getAccountTools({ account, readOnly }));
+    }
+
+    if (enabledFeatures.has('database') && database) {
+      Object.assign(tools, getDatabaseOperationTools({ database, readOnly }));
+    }
+
+    return tools;
+  },
+});
+```
+
+## Read-Only Mode
+
+When `readOnly: true`, tools that modify state should either:
+1. Not be registered
+2. Throw an error on execute

--- a/packages/mcp-server-supabase/AGENTS.md
+++ b/packages/mcp-server-supabase/AGENTS.md
@@ -1,0 +1,106 @@
+# AGENTS Guidelines for This Package
+
+This package (`@supabase/mcp-server-supabase`) is the main Supabase MCP server implementation.
+When working on this package interactively with an agent, please follow the guidelines below.
+
+## 1. Use Development Mode, **not** Production Builds
+
+* **Always use `pnpm dev`** while iterating on the package. This starts tsup in watch mode
+  with hot-reload enabled, automatically rebuilding on file changes.
+
+* **Do _not_ run `pnpm build` inside the agent session.** Running the production build
+  command is slow and unnecessary during development. The `prebuild` hook runs
+  `typecheck` automatically, so type errors will fail builds anyway. If a production
+  build is required, do it outside of the interactive agent workflow.
+
+## 2. Testing the Package Locally
+
+To test the local build with an MCP client (e.g., Cursor):
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@file:/absolute/path/to/packages/mcp-server-supabase",
+        "--project-ref",
+        "<your project ref>"
+      ],
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "<your pat>"
+      }
+    }
+  }
+}
+```
+
+* Use absolute path for `file:` protocol
+* Restart MCP client after rebuilding
+* Optional: Use `--api-url` to point at different Supabase instance
+
+## 3. Running Tests
+
+* **Unit tests:** `pnpm test:unit` - Fast tests, 30s timeout
+* **E2E tests:** `pnpm test:e2e` - Requires `SUPABASE_ACCESS_TOKEN`, 60s timeout, uses MSW mocks
+* **Integration tests:** `pnpm test:integration` - 30s timeout
+* **All tests:** `pnpm test` - Runs all test projects
+* **Coverage:** `pnpm test:coverage` - Generates coverage report in `test/coverage/`
+
+## 4. Code Generation
+
+* **Management API types:** Run `pnpm generate:management-api-types` to regenerate types
+  from Supabase OpenAPI spec. Do NOT edit `src/management-api/types.ts` manually.
+
+## 5. Publishing to MCP Registry
+
+When publishing a new version:
+
+1. Update version in `package.json` (follow semver)
+2. Run `pnpm registry:update` to sync version to `server.json`
+3. Ensure `domain-verification-key.pem` is in package directory
+4. Run `pnpm registry:login` to authenticate
+5. Run `pnpm registry:publish` to publish metadata
+
+**⚠️ Important:** Do NOT edit `server.json` manually - use `registry:update` script.
+
+## 6. Useful Commands
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm dev` | **Start dev server with watch mode** |
+| `pnpm typecheck` | Type check without emitting files |
+| `pnpm test` | Run all test projects |
+| `pnpm test:unit` | Run unit tests only |
+| `pnpm test:e2e` | Run e2e tests only |
+| `pnpm test:integration` | Run integration tests only |
+| `pnpm format` | Format files (run from repo root) |
+| `pnpm build` | **Production build – _do not run during agent sessions_** |
+
+## 7. Package Structure
+
+* `src/tools/` - MCP tool implementations
+* `src/transports/` - Transport layer (stdio)
+* `src/platform/` - Platform-specific implementations
+* `src/pg-meta/` - PostgreSQL metadata queries (SQL files)
+* `src/management-api/` - Supabase Management API client (types auto-generated)
+* `src/content-api/` - Content API (GraphQL) client
+* `test/e2e/` - End-to-end tests
+* `test/` - Integration tests and utilities
+
+## 8. What NOT to Commit
+
+* Do NOT commit `dist/` files (they're gitignored)
+* Do NOT commit `.env.local` or coverage files
+* Do NOT manually edit `src/management-api/types.ts` (it's auto-generated)
+* Do NOT manually edit `server.json` (use `registry:update` script)
+
+---
+
+**Tech Stack:** TypeScript, Vitest (unit/e2e/integration), tsup, MCP SDK, GraphQL/PostgREST/OpenAPI Fetch
+
+**Build Outputs:** Multiple entry points (index, stdio transport, platform exports) to `dist/` with CJS, ESM, types, and sourcemaps.
+
+Following these practices ensures that the agent-assisted development workflow stays fast and
+dependable. When in doubt, restart the dev server rather than running the production build.

--- a/packages/mcp-server-supabase/AGENTS.md
+++ b/packages/mcp-server-supabase/AGENTS.md
@@ -1,126 +1,49 @@
 # AGENTS.md
 
-This file provides guidance for AI agents working on this package.
+This file provides guidance to AI coding agents working on this package.
 
-> See also: [Root AGENTS.md](../../AGENTS.md) for repository-wide guidelines.
+## Build & Test Commands
 
-## Package Overview
+```sh
+pnpm build            # Production build (runs typecheck first)
+pnpm dev              # Watch mode with auto-rebuild
+pnpm typecheck        # Type check without emitting
 
-`@supabase/mcp-server-supabase` - Main MCP server for Supabase platform. Provides tools for database operations, edge functions, storage, branching, and more.
+pnpm test             # Run all tests
+pnpm test:unit        # Unit tests only
+pnpm test:e2e         # E2E tests (requires SUPABASE_ACCESS_TOKEN)
+pnpm test:integration # Integration tests
 
-## Development Environment
-
-### Setup
-
-From repository root:
-```bash
-mise install
-pnpm install
+pnpm generate:management-api-types   # Regenerate API types from OpenAPI
+pnpm registry:update                 # Update server.json for MCP registry
 ```
 
-### Development Mode
+## Environment Variables
 
-```bash
-cd packages/mcp-server-supabase
-pnpm dev        # Watch mode with auto-rebuild
-```
+| Variable | Required For |
+|----------|--------------|
+| `SUPABASE_ACCESS_TOKEN` | E2E tests, running the server |
+| `ANTHROPIC_API_KEY` | AI test matcher |
 
-### Testing Locally with MCP Client
+## Code Style
 
-```json
-{
-  "mcpServers": {
-    "supabase": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@supabase/mcp-server-supabase@file:/absolute/path/to/packages/mcp-server-supabase",
-        "--project-ref",
-        "<your project ref>"
-      ],
-      "env": {
-        "SUPABASE_ACCESS_TOKEN": "<your pat>"
-      }
-    }
-  }
-}
-```
-
-## Commands Reference
-
-### Build
-
-| Command | Description |
-|---------|-------------|
-| `pnpm build` | Production build |
-| `pnpm dev` | Watch mode with auto-rebuild |
-| `pnpm typecheck` | Type check without emitting |
-
-### Test
-
-| Command | Description |
-|---------|-------------|
-| `pnpm test` | Run all tests |
-| `pnpm test:unit` | Unit tests only |
-| `pnpm test:e2e` | E2E tests (requires `SUPABASE_ACCESS_TOKEN`) |
-| `pnpm test:integration` | Integration tests only |
-| `pnpm test:coverage` | Tests with coverage report |
-
-### Code Generation
-
-| Command | Description |
-|---------|-------------|
-| `pnpm generate:management-api-types` | Regenerate Management API types from OpenAPI |
-
-## Code Style Guidelines
-
-See [Root AGENTS.md](../../AGENTS.md#code-style-guidelines).
-
-## Testing Patterns
-
-### File Naming
-- Unit tests: `*.test.ts` (co-located in `src/`)
-- E2E tests: `*.e2e.ts` (in `test/e2e/`)
-- Integration tests: `*.integration.ts`
-
-### Test Infrastructure
-- **HTTP mocking**: MSW (Mock Service Worker) in `test/mocks.ts`
-- **Database**: PGlite (in-memory PostgreSQL)
-- **AI testing**: Custom `toMatchCriteria()` matcher using Claude API
-
-### Environment Variables for Tests
-
-| Variable | Required For | Description |
-|----------|--------------|-------------|
-| `SUPABASE_ACCESS_TOKEN` | E2E tests | Personal access token |
-| `ANTHROPIC_API_KEY` | AI matcher | Used by `toMatchCriteria()` |
-
-### Source Structure
-
-```
-src/
-├── tools/                  # MCP tool implementations
-├── management-api/         # Supabase Management API client
-│   └── types.ts            # AUTO-GENERATED - do not edit
-├── content-api/            # Documentation API
-├── pg-meta/                # Database introspection
-├── platform/               # Platform abstractions
-├── transports/             # IPC transports (stdio)
-└── server.ts               # Main MCP server
-```
+- Biome formatting (single quotes, ES5 trailing commas, 2-space indent)
+- ESM imports with `.js` extensions
+- Zod schemas for all external inputs
+- Tests: `*.test.ts` co-located, `*.e2e.ts` in `test/e2e/`
 
 ## Do NOT
 
-- Edit `src/management-api/types.ts` - regenerate with `pnpm generate:management-api-types`
-- Edit `server.json` manually - use `pnpm registry:update`
+- Edit `src/management-api/types.ts` - use `pnpm generate:management-api-types`
+- Edit `server.json` - use `pnpm registry:update`
+- Skip HTTP mocking in unit tests - use MSW
+- Run `pnpm build` during development - use `pnpm dev`
 - Commit `.env.local` or access tokens
-- Skip mocking HTTP calls in unit tests - use MSW
-- Run `pnpm build` during development - use `pnpm dev` instead
 
-## Keeping AGENTS.md Up to Date
+## Agent Skills
 
-Update this file when you change:
-- Package scripts in `package.json`
-- Test configuration in `vitest.config.ts` or `vitest.workspace.ts`
-- Source structure (new directories or major reorganization)
-- Environment variable requirements
+For detailed patterns and architecture, see the on-demand skills in `.claude/skills/`:
+
+- **architecture** - Source structure, core layers, data flow
+- **testing** - MSW mocking, PGlite, AI test matcher patterns
+- **tool-registration** - Creating and registering MCP tools

--- a/packages/mcp-server-supabase/CLAUDE.md
+++ b/packages/mcp-server-supabase/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](@supabase/mcp-server-supabase/AGENTS.md) for package guidelines.

--- a/packages/mcp-utils/.claude/skills/server-patterns/SKILL.md
+++ b/packages/mcp-utils/.claude/skills/server-patterns/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: mcp-utils-server-patterns
+description: MCP server creation patterns using mcp-utils. Use when creating new MCP servers, understanding the server factory, or working with tool/resource registration.
+---
+
+# Server Patterns
+
+## Creating a Server
+
+```typescript
+import { createMcpServer, tool } from '@supabase/mcp-utils';
+import { z } from 'zod';
+
+const server = createMcpServer({
+  name: 'my-server',
+  version: '1.0.0',
+  tools: {
+    my_tool: tool({
+      description: 'Does something',
+      parameters: z.object({ input: z.string() }),
+      execute: async ({ input }) => ({ result: input }),
+    }),
+  },
+});
+
+await server.connect(transport);
+```
+
+## The `tool()` Helper
+
+Preserves Zod schema types for strong typing:
+
+```typescript
+export function tool<Params extends z.ZodObject<any>, Result>(
+  tool: Tool<Params, Result>
+) {
+  return tool;
+}
+```
+
+## Tool Structure
+
+```typescript
+type Tool<Params, Result> = {
+  description: string;
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+  parameters: Params;
+  execute(params: z.infer<Params>): Promise<Result>;
+};
+```
+
+## Dynamic Tool Registration
+
+Tools can be a function for dynamic loading:
+
+```typescript
+const server = createMcpServer({
+  name: 'my-server',
+  tools: async () => {
+    const tools = {};
+    if (featureEnabled) {
+      Object.assign(tools, getFeatureTools());
+    }
+    return tools;
+  },
+});
+```
+
+## StreamTransport for Testing
+
+```typescript
+const clientTransport = new StreamTransport();
+const serverTransport = new StreamTransport();
+
+clientTransport.readable.pipeTo(serverTransport.writable);
+serverTransport.readable.pipeTo(clientTransport.writable);
+```

--- a/packages/mcp-utils/AGENTS.md
+++ b/packages/mcp-utils/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+This file provides guidance for AI agents working on this package.
+
+> See also: [Root AGENTS.md](../../AGENTS.md) for repository-wide guidelines.
+
+## Package Overview
+
+`@supabase/mcp-utils` - Shared utilities and base classes for MCP servers. This is a dependency of `mcp-server-supabase`.
+
+## Development Environment
+
+### Setup
+
+From repository root:
+```bash
+mise install
+pnpm install
+```
+
+### Development Mode
+
+```bash
+cd packages/mcp-utils
+pnpm dev        # Watch mode with auto-rebuild
+```
+
+## Commands Reference
+
+### Build
+
+| Command | Description |
+|---------|-------------|
+| `pnpm build` | Production build |
+| `pnpm dev` | Watch mode with auto-rebuild |
+| `pnpm typecheck` | Type check without emitting |
+
+### Test
+
+| Command | Description |
+|---------|-------------|
+| `pnpm test` | Run all tests |
+| `pnpm test:coverage` | Tests with coverage report |
+
+## Code Style Guidelines
+
+See [Root AGENTS.md](../../AGENTS.md#code-style-guidelines).
+
+## Testing Patterns
+
+### File Naming
+- Unit tests: `*.test.ts` (co-located in `src/`)
+
+### Source Structure
+```
+src/
+├── index.ts      # Main export
+├── server.ts     # Base server implementation
+├── types.ts      # Common types
+└── util.ts       # Utilities
+```
+
+## Do NOT
+
+- Break the public API without updating `mcp-server-supabase`
+- Add heavy dependencies - this is a utility package
+- Run `pnpm build` during development - use `pnpm dev` instead
+
+## Keeping AGENTS.md Up to Date
+
+Update this file when you change:
+- Package scripts in `package.json`
+- Source structure or public API
+- Dependencies that affect consumers

--- a/packages/mcp-utils/AGENTS.md
+++ b/packages/mcp-utils/AGENTS.md
@@ -1,74 +1,32 @@
 # AGENTS.md
 
-This file provides guidance for AI agents working on this package.
+This file provides guidance to AI coding agents working on this package.
 
-> See also: [Root AGENTS.md](../../AGENTS.md) for repository-wide guidelines.
+## Build & Test Commands
 
-## Package Overview
+```sh
+pnpm build        # Production build (runs typecheck first)
+pnpm dev          # Watch mode with auto-rebuild
+pnpm typecheck    # Type check without emitting
 
-`@supabase/mcp-utils` - Shared utilities and base classes for MCP servers. This is a dependency of `mcp-server-supabase`.
-
-## Development Environment
-
-### Setup
-
-From repository root:
-```bash
-mise install
-pnpm install
+pnpm test         # Run all tests
+pnpm test:coverage
 ```
 
-### Development Mode
+## Key Exports
 
-```bash
-cd packages/mcp-utils
-pnpm dev        # Watch mode with auto-rebuild
-```
-
-## Commands Reference
-
-### Build
-
-| Command | Description |
-|---------|-------------|
-| `pnpm build` | Production build |
-| `pnpm dev` | Watch mode with auto-rebuild |
-| `pnpm typecheck` | Type check without emitting |
-
-### Test
-
-| Command | Description |
-|---------|-------------|
-| `pnpm test` | Run all tests |
-| `pnpm test:coverage` | Tests with coverage report |
-
-## Code Style Guidelines
-
-See [Root AGENTS.md](../../AGENTS.md#code-style-guidelines).
-
-## Testing Patterns
-
-### File Naming
-- Unit tests: `*.test.ts` (co-located in `src/`)
-
-### Source Structure
-```
-src/
-├── index.ts      # Main export
-├── server.ts     # Base server implementation
-├── types.ts      # Common types
-└── util.ts       # Utilities
-```
+- `createMcpServer()` - Server factory with tool/resource registration
+- `tool()` - Type-safe tool definition helper
+- `StreamTransport` - Bidirectional stream transport for testing
 
 ## Do NOT
 
 - Break the public API without updating `mcp-server-supabase`
-- Add heavy dependencies - this is a utility package
-- Run `pnpm build` during development - use `pnpm dev` instead
+- Add heavy dependencies - this is a lightweight utility package
+- Run `pnpm build` during development - use `pnpm dev`
 
-## Keeping AGENTS.md Up to Date
+## Agent Skills
 
-Update this file when you change:
-- Package scripts in `package.json`
-- Source structure or public API
-- Dependencies that affect consumers
+For detailed patterns, see the on-demand skills in `.claude/skills/`:
+
+- **server-patterns** - MCP server creation, tool() helper, dynamic registration

--- a/packages/mcp-utils/CLAUDE.md
+++ b/packages/mcp-utils/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](@supabase/mcp-utils/AGENTS.md) for package guidelines.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation — Introduces standardized AI guidance files to help AI coding agents work effectively on this codebase.

## What is the current behavior?

AI coding agents (Claude Code, Cursor, GitHub Copilot, etc.) have no project-specific context when working on this repository, that could lead to:
- Running `pnpm build` during development instead of `pnpm dev`
- Editing auto-generated files (`types.ts`, `server.json`) that should never be modified manually
- Missing environment variables for tests
- Inconsistent code patterns

## What is the new behavior?

This PR adds a layered system of AI guidance files:

| File Type | Purpose |
|-----------|---------|
| `CLAUDE.md` | Entry point that links to AGENTS.md |
| `AGENTS.md` | Commands, setup, code style, "Do NOT" warnings |
| Agent Skills | On-demand detailed patterns (testing, architecture, tool registration) |

**Hierarchy:**

1. **CLAUDE.md** (root + packages) — Links to AGENTS.md

2. **Root AGENTS.md** — Repo-wide basics: monorepo structure, build/test commands, package manager, dev dependencies. Points to package-specific guides.

3. **Package AGENTS.md** — Package-specific commands, environment variables, code style, "Do NOT" warnings. References Skills for detailed patterns.

4. **Agent Skills** (`.claude/skills/`) — On-demand loading of detailed architecture, testing patterns, and tool registration guides. Only loaded when triggered by relevant tasks ([Agent Skills docs](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)).

**Files added:**
- AGENTS.md and CLAUDE.md at root and package levels
- Agent Skills in `.claude/skills/` directories

## Note on Agent Skills

The Agent Skills in this PR are **Claude-specific**. While an open standard for agent skills has been proposed, it is not yet stable:
- [OpenAI Codex Skills](https://developers.openai.com/codex/skills/) — Experimental feature
- [Cursor Skills](https://cursor.com/docs/context/skills) — Only available in nightly builds

Once agent skills are officially adopted as an industry standard, we can adapt these files accordingly. This provides a good starting foundation.

## References

- [Using CLAUDE.md Files](https://claude.com/blog/using-claude-md-files) — Anthropic blog post
- [Claude Code Best Practices](https://www.anthropic.com/engineering/claude-code-best-practices) — Anthropic engineering guide
- [AGENTS.md Specification](https://agents.md/) — Industry-standard format for AI agent guidance
- [Agent Skills Overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) — On-demand skill loading
