### PR TITLE
fix deploy edge function description

### DIFF
--- a/packages/mcp-server-supabase/src/tools/edge-function-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/edge-function-tools.ts
@@ -87,7 +87,7 @@ export function getEdgeFunctionTools({
             })
           )
           .describe(
-            'The files to upload. This should include the entrypoint, deno.json, and any relative dependencies. Always include a deno.json file to configure the Deno runtime (e.g., compiler options, imports).'
+            'The files to upload. This should include the entrypoint, deno.json, and any relative dependencies. Include the deno.json and deno.jsonc files to configure the Deno runtime (e.g., compiler options, imports) if they exist.'
           ),
       }),
       inject: { project_id },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (tool description improvement)

## What is the current behavior?

The `deploy_edge_function` tool description states that a `deno.json` file should **always** be included when deploying edge functions, which could mislead AI agents into creating unnecessary `deno.json` files when they don't exist in the project.

## What is the new behavior?

The description now clarifies that `deno.json` and `deno.jsonc` files should only be included **if they exist**, making it conditional rather than mandatory.

```diff
- 'The files to upload. This should include the entrypoint, deno.json, and any relative dependencies. Always include a deno.json file to configure the Deno runtime (e.g., compiler options, imports).'
+ 'The files to upload. This should include the entrypoint, deno.json, and any relative dependencies. Include the deno.json and deno.jsonc files to configure the Deno runtime (e.g., compiler options, imports) if they exist.'
```

## Additional context

This prevents AI agents from unnecessarily creating `deno.json` files when deploying edge functions that don't have one configured.
