### PR TITLE
chore: --compact preview URLs

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -34,4 +34,4 @@ jobs:
         run: pnpm build
 
       - name: Publish preview packages
-        run: pnpm dlx pkg-pr-new@latest publish --pnpm --packageManager=pnpm './packages/mcp-utils' './packages/mcp-server-supabase'
+        run: pnpm dlx pkg-pr-new@latest publish --compact --pnpm --packageManager=pnpm './packages/mcp-utils' './packages/mcp-server-supabase'


### PR DESCRIPTION
Adds `--compact` flag for shorter preview URLs.

In https://github.com/supabase-community/supabase-mcp/pull/196 we added ["repository"](https://github.com/supabase-community/supabase-mcp/blob/a994bb46046c318dcc95dc9514096dd657475ac5/packages/mcp-server-supabase/package.json#L7-L10) info in the package metadata, now that the change has been published to NPM we can enable this flag.