### PR TITLE
bump @modelcontextprotocol/sdk library from 12.23.1 to 1.25.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^1.0.1
       version: 1.0.1
     '@modelcontextprotocol/sdk':
-      specifier: 1.23.1
-      version: 1.23.1
+      specifier: 1.25.2
+      version: 1.25.2
     ai:
       specifier: ^6.0.3
       version: 6.0.3
@@ -37,7 +37,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.23.1(zod@4.2.1)
+        version: 1.25.2(hono@4.11.4)(zod@4.2.1)
       '@supabase/mcp-utils':
         specifier: workspace:^
         version: link:../mcp-utils
@@ -80,7 +80,7 @@ importers:
         version: 0.10.1
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.23.1(zod@4.2.1)
+        version: 1.25.2(hono@4.11.4)(zod@4.2.1)
       '@supabase/mcp-utils':
         specifier: workspace:^
         version: link:../mcp-utils
@@ -165,7 +165,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.23.1(zod@4.2.1)
+        version: 1.25.2(hono@4.11.4)(zod@4.2.1)
     devDependencies:
       '@total-typescript/tsconfig':
         specifier: ^1.0.4
@@ -609,6 +609,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.8':
+    resolution: {integrity: sha512-0/g2lIOPzX8f3vzW1ggQgvG5mjtFBDBHFAzI5SFAi2DzSqS9luJwqg9T6O/gKYLi+inS7eNxBeIFkkghIPvrMA==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@inquirer/confirm@5.1.15':
     resolution: {integrity: sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==}
     engines: {node: '>=18'}
@@ -671,8 +677,8 @@ packages:
   '@mjackson/multipart-parser@0.10.1':
     resolution: {integrity: sha512-cHMD6+ErH/DrEfC0N6Ru/+1eAdavxdV0C35PzSb5/SD7z3XoaDMc16xPJcb8CahWjSpqHY+Too9sAb6/UNuq7A==}
 
-  '@modelcontextprotocol/sdk@1.23.1':
-    resolution: {integrity: sha512-JvO6eVMbSKdk+iZcwECz/tra9DRAKlv1mAOsQ1DAWU3qG28tDIffpkEAUkqMMwlOq77GhnMpezEjiQJGIR+hHw==}
+  '@modelcontextprotocol/sdk@1.25.2':
+    resolution: {integrity: sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -1279,6 +1285,10 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
+  hono@4.11.4:
+    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1341,6 +1351,9 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -1358,6 +1371,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -2297,6 +2313,10 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@hono/node-server@1.19.8(hono@4.11.4)':
+    dependencies:
+      hono: 4.11.4
+
   '@inquirer/confirm@5.1.15(@types/node@22.17.2)':
     dependencies:
       '@inquirer/core': 10.1.15(@types/node@22.17.2)
@@ -2358,8 +2378,9 @@ snapshots:
     dependencies:
       '@mjackson/headers': 0.11.1
 
-  '@modelcontextprotocol/sdk@1.23.1(zod@4.2.1)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.11.4)(zod@4.2.1)':
     dependencies:
+      '@hono/node-server': 1.19.8(hono@4.11.4)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -2369,11 +2390,14 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.1.0
       express-rate-limit: 7.5.1(express@5.1.0)
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 4.2.1
       zod-to-json-schema: 3.25.1(zod@4.2.1)
     transitivePeerDependencies:
+      - hono
       - supports-color
 
   '@mswjs/interceptors@0.39.6':
@@ -2994,6 +3018,8 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  hono@4.11.4: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.0:
@@ -3058,6 +3084,8 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jose@6.1.3: {}
+
   joycon@3.1.1: {}
 
   js-levenshtein@1.1.6: {}
@@ -3069,6 +3097,8 @@ snapshots:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,6 @@ onlyBuiltDependencies:
 catalog:
   '@ai-sdk/anthropic': ^3.0.1
   '@ai-sdk/mcp': ^1.0.1
-  '@modelcontextprotocol/sdk': 1.23.1
+  '@modelcontextprotocol/sdk': 1.25.2
   ai: ^6.0.3
   zod: ^3.25.0 || ^4.0.0


### PR DESCRIPTION
 ## Summary
 
1. Why:
To remove CVEs:
     - HIGH severity [CVE-2025-66414](https://avd.aquasec.com/nvd/cve-2025-66414)
     
     - HIGH severity [CVE-2026-0621](https://avd.aquasec.com/nvd/2026/cve-2026-0621)

2. What:
     - Upgrade @modelcontextprotocol/sdk library to 1.25.2 version to remove [CVE-2025-66414](https://avd.aquasec.com/nvd/cve-2025-66414) and [CVE-2026-0621](https://avd.aquasec.com/nvd/2026/cve-2026-0621)
 
 ## Additional evidence
 Partial output from security scanner Trivy:
<img width="1230" height="155" alt="cves supabas-mcp modelcontextprotocol" src="https://github.com/user-attachments/assets/12e570a9-2169-4747-9213-fcb9e7491df3" />

 ## Categorization
 
- [x] security/CVE