### PR TITLE
fix: update JSON Schema target from `draft-07` to `draft-7`

### DIFF
--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -442,7 +442,7 @@ export function createMcpServer(options: McpServerOptions) {
             Object.entries(tools).map(
               async ([name, { description, annotations, parameters }]) => {
                 const inputSchema = z.toJSONSchema(parameters, {
-                  target: 'draft-07',
+                  target: 'draft-7',
                 });
 
                 return {


### PR DESCRIPTION
Updates `z.toJSONSchema()` target to `draft-7`. The end result is the same (normalizes to `draft-07`) but this approach works in both Zod 3.25+ and Zod 4.0+ to prevent the flood of `Invalid target: draft-07` messages.

Related: https://github.com/colinhacks/zod/pull/5659

Resolves AI-383