### PR TITLE
v0.6.3

### DIFF
--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supabase/mcp-server-supabase",
   "mcpName": "com.supabase/mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "MCP server for interacting with Supabase",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-server-supabase/server.json
+++ b/packages/mcp-server-supabase/server.json
@@ -46,7 +46,7 @@
     "subfolder": "packages/mcp-server-supabase"
   },
   "websiteUrl": "https://supabase.com/mcp",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "remotes": [
     {
       "type": "streamable-http",
@@ -58,7 +58,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@supabase/mcp-server-supabase",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
**Changes**
- Bumps `@supabase/mcp-server-supabase` version to v0.6.3

**Included in Release:**
- fix: move Zod .describe() schemas to module level to prevent memory leak (#215)

Resolves AI-410