### PR TITLE
chore: split coveralls upload into separate job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,24 @@ jobs:
           pnpm rebuild # To create bin links
       - name: Tests
         run: pnpm run test:coverage
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: ./packages/mcp-server-supabase/coverage/lcov.info
+          retention-days: 1
+  coveralls:
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ always() && needs.test.result == 'success' }}
+    continue-on-error: true
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           base-path: ./packages/mcp-server-supabase
+          file: lcov.info


### PR DESCRIPTION
Splits the Coveralls upload step into a separate downstream job with `continue-on-error: true` so a Coveralls outage doesn't cause the `test` check on PRs to appear as failing.

Coverage is passed between jobs via a GitHub Actions artifact.

Note the failing [❌ Tests / coveralls (pull_request)](https://github.com/supabase-community/supabase-mcp/actions/runs/22402467748/job/64852890135?pr=225) on this PR is expected while there's a Coveralls outage.

**References:**
- https://github.com/supabase/supabase/pull/43171
- https://github.com/supabase/supabase/pull/43175