### PR TITLE
docs: improve tool descriptions for better LLM tool selection

### DIFF
--- a/packages/mcp-server-postgrest/src/server.ts
+++ b/packages/mcp-server-postgrest/src/server.ts
@@ -63,7 +63,8 @@ export function createPostgrestMcpServer(options: PostgrestMcpServerOptions) {
     ]),
     tools: {
       postgrestRequest: tool({
-        description: 'Performs an HTTP request against the PostgREST API',
+        description:
+          'Sends an HTTP request to the PostgREST API to query or modify data. Use `method` and `path` to target a specific table (e.g. GET /users?id=eq.1). For write operations (POST, PATCH, DELETE), include a `body` with the row data. Prefer `sqlToRest` to convert SQL queries into the equivalent PostgREST request.',
         parameters: z.object({
           method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
           path: z.string(),

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -189,7 +189,8 @@ export const accountToolDefs = {
     },
   },
   pause_project: {
-    description: 'Pauses a Supabase project.',
+    description:
+      'Pauses a Supabase project. The database and APIs will become unavailable while paused. Use `restore_project` to resume. Always confirm with the user before pausing.',
     parameters: pauseProjectInputSchema,
     outputSchema: pauseProjectOutputSchema,
     annotations: {
@@ -201,7 +202,8 @@ export const accountToolDefs = {
     },
   },
   restore_project: {
-    description: 'Restores a Supabase project.',
+    description:
+      'Restores a previously paused Supabase project. The database and APIs will become available again once restoration completes. Use `get_project` to check the project status after restoring.',
     parameters: restoreProjectInputSchema,
     outputSchema: restoreProjectOutputSchema,
     annotations: {

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -116,7 +116,8 @@ export const databaseToolDefs = {
     },
   },
   list_extensions: {
-    description: 'Lists all extensions in the database.',
+    description:
+      'Lists all Postgres extensions available in the database, including their install status (e.g. pgvector, postgis, uuid-ossp). Use to check database capabilities before enabling a new extension via `apply_migration`.',
     parameters: listExtensionsInputSchema,
     outputSchema: listExtensionsOutputSchema,
     annotations: {
@@ -128,7 +129,8 @@ export const databaseToolDefs = {
     },
   },
   list_migrations: {
-    description: 'Lists all migrations in the database.',
+    description:
+      'Lists all migrations applied to the database. Use to review migration history or verify that a recently applied migration succeeded.',
     parameters: listMigrationsInputSchema,
     outputSchema: listMigrationsOutputSchema,
     annotations: {


### PR DESCRIPTION
## Summary

Improves tool descriptions for 5 MCP tools that currently have minimal descriptions. Each improvement adds domain-specific context that helps LLM agents:

- **Select the right tool** by understanding when to use it (scenario triggers)
- **Understand consequences** before invoking (e.g. pausing terminates connections)
- **Discover related tools** via cross-references (e.g. `restore_project` from `pause_project`)

### Changes

| Tool | What was added |
|------|---------------|
| `postgrestRequest` | Usage pattern with example path, write operation guidance, cross-ref to `sqlToRest` |
| `pause_project` | Billing/availability impact, safety warning about active connections, cross-ref to `restore_project` |
| `restore_project` | Prerequisite context (previously paused), status check via `get_project` |
| `list_extensions` | Concrete examples (pgvector, postgis, uuid-ossp), scenario trigger for capability checks |
| `list_migrations` | Ordering information, verification scenario after applying migrations |

### What this does NOT change

- No parameter schemas modified
- No behavioral/execution logic changes
- No new dependencies
- Existing well-described tools (e.g. `execute_sql`, `create_project`, `apply_migration`) left untouched

## Test plan

- [ ] Verify descriptions render correctly in MCP inspector
- [ ] Confirm no parameter schema changes in tool listing
- [ ] Spot-check that LLM agents select `pause_project` / `restore_project` correctly in context