### PR TITLE
fix: sync management API types and add slug to list_organizations output

### DIFF
--- a/.github/workflows/check-management-api-types.yml
+++ b/.github/workflows/check-management-api-types.yml
@@ -1,0 +1,26 @@
+name: Check Management API Types
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+        with:
+          install: true
+          cache: true
+      - name: Install dependencies
+        run: pnpm install --ignore-scripts
+      - name: Regenerate management API types
+        run: pnpm --filter @supabase/mcp-server-supabase generate:management-api-types
+      - name: Check for diff
+        run: |
+          if ! git diff --exit-code packages/mcp-server-supabase/src/management-api/types.ts; then
+            echo "Management API types are out of date. Run 'pnpm generate:management-api-types' to update."
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
     if: ${{ always() && needs.test.result == 'success' }}
     continue-on-error: true
     steps:
+      - uses: actions/checkout@v4
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:

--- a/packages/mcp-server-supabase/.gitignore
+++ b/packages/mcp-server-supabase/.gitignore
@@ -1,2 +1,2 @@
-test/coverage
+coverage
 *.pem

--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -1691,6 +1691,7 @@ export interface components {
         };
         OrganizationResponseV1: {
             id: string;
+            slug: string;
             name: string;
         };
         CreateOrganizationV1: {

--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/v1/branches/{branch_id}": {
+    "/v1/branches/{branch_id_or_ref}": {
         parameters: {
             query?: never;
             header?: never;
@@ -20,7 +20,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a database branch
-         * @description Deletes the specified database branch
+         * @description Deletes the specified database branch. By default, deletes immediately. Use force=false to schedule deletion with 1-hour grace period (only when soft deletion is enabled).
          */
         delete: operations["v1-delete-a-branch"];
         options?: never;
@@ -32,7 +32,7 @@ export interface paths {
         patch: operations["v1-update-a-branch-config"];
         trace?: never;
     };
-    "/v1/branches/{branch_id}/push": {
+    "/v1/branches/{branch_id_or_ref}/push": {
         parameters: {
             query?: never;
             header?: never;
@@ -52,7 +52,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/branches/{branch_id}/merge": {
+    "/v1/branches/{branch_id_or_ref}/merge": {
         parameters: {
             query?: never;
             header?: never;
@@ -72,7 +72,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/branches/{branch_id}/reset": {
+    "/v1/branches/{branch_id_or_ref}/reset": {
         parameters: {
             query?: never;
             header?: never;
@@ -92,7 +92,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/branches/{branch_id}/diff": {
+    "/v1/branches/{branch_id_or_ref}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore a scheduled branch deletion
+         * @description Cancels scheduled deletion and restores the branch to active state
+         */
+        post: operations["v1-restore-a-branch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/branches/{branch_id_or_ref}/diff": {
         parameters: {
             query?: never;
             header?: never;
@@ -122,11 +142,30 @@ export interface paths {
         /**
          * List all projects
          * @description Returns a list of all projects you've previously created.
+         *
+         *     Use `/v1/organizations/{slug}/projects` instead when possible to get more precise results and pagination support.
          */
         get: operations["v1-list-all-projects"];
         put?: never;
         /** Create a project */
         post: operations["v1-create-a-project"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/available-regions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** [Beta] Gets the list of available regions that can be used for a new project */
+        get: operations["v1-get-available-regions"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -259,6 +298,90 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{ref}/actions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all action runs
+         * @description Returns a paginated list of action runs of the specified project.
+         */
+        get: operations["v1-list-action-runs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        /**
+         * Count the number of action runs
+         * @description Returns the total number of action runs of the specified project.
+         */
+        head: operations["v1-count-action-runs"];
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/actions/{run_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the status of an action run
+         * @description Returns the current status of the specified action run.
+         */
+        get: operations["v1-get-action-run"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/actions/{run_id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update the status of an action run
+         * @description Updates the status of an ongoing action run.
+         */
+        patch: operations["v1-update-action-run-status"];
+        trace?: never;
+    };
+    "/v1/projects/{ref}/actions/{run_id}/logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the logs of an action run
+         * @description Returns the logs from the specified action run.
+         */
+        get: operations["v1-get-action-run-logs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{ref}/api-keys": {
         parameters: {
             query?: never;
@@ -342,6 +465,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{ref}/branches/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a database branch
+         * @description Fetches the specified database branch by its name.
+         */
+        get: operations["v1-get-a-branch"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{ref}/custom-hostname": {
         parameters: {
             query?: never;
@@ -405,6 +548,24 @@ export interface paths {
         put?: never;
         /** [Beta] Activates a custom hostname for a project. */
         post: operations["v1-activate-custom-hostname"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/jit-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** [Beta] Get project's just-in-time access configuration. */
+        get: operations["v1-get-jit-access-config"];
+        /** [Beta] Update project's just-in-time access configuration. */
+        put: operations["v1-update-jit-access-config"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -476,7 +637,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /** [Alpha] Updates project's network restrictions by adding or removing CIDRs */
+        patch: operations["v1-patch-network-restrictions"];
         trace?: never;
     };
     "/v1/projects/{ref}/network-restrictions/apply": {
@@ -547,7 +709,8 @@ export interface paths {
         delete: operations["v1-delete-a-project"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** Updates the given project */
+        patch: operations["v1-update-a-project"];
         trace?: never;
     };
     "/v1/projects/{ref}/secrets": {
@@ -859,77 +1022,6 @@ export interface paths {
         patch: operations["v1-update-project-signing-key"];
         trace?: never;
     };
-    "/v1/projects/{ref}/config/storage": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Gets project's storage config */
-        get: operations["v1-get-storage-config"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Updates project's storage config */
-        patch: operations["v1-update-storage-config"];
-        trace?: never;
-    };
-    "/v1/projects/{ref}/config/database/postgres": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Gets project's Postgres config */
-        get: operations["v1-get-postgres-config"];
-        /** Updates project's Postgres config */
-        put: operations["v1-update-postgres-config"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/projects/{ref}/config/database/pgbouncer": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get project's pgbouncer config */
-        get: operations["v1-get-project-pgbouncer-config"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/projects/{ref}/config/database/pooler": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Gets project's supavisor config */
-        get: operations["v1-get-pooler-config"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Updates project's supavisor config */
-        patch: operations["v1-update-pooler-config"];
-        trace?: never;
-    };
     "/v1/projects/{ref}/config/auth": {
         parameters: {
             query?: never;
@@ -1043,14 +1135,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Lists project addons */
+        /**
+         * List billing addons and compute instance selections
+         * @description Returns the billing addons that are currently applied, including the active compute instance size, and lists every addon option that can be provisioned with pricing metadata.
+         */
         get: operations["v1-list-project-addons"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
-        /** Applies project addon */
+        /**
+         * Apply or update billing addons, including compute instance size
+         * @description Selects an addon variant, for example scaling the project’s compute instance up or down, and applies it to the project.
+         */
         patch: operations["v1-apply-project-addon"];
         trace?: never;
     };
@@ -1064,7 +1162,10 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        /** Removes project addon */
+        /**
+         * Remove billing addons or revert compute instance sizing
+         * @description Disables the selected addon variant, including rolling the compute instance back to its previous size.
+         */
         delete: operations["v1-remove-project-addon"];
         options?: never;
         head?: never;
@@ -1143,9 +1244,11 @@ export interface paths {
          * Gets project's logs
          * @description Executes a SQL query on the project's logs.
          *
-         *     Either the 'iso_timestamp_start' and 'iso_timestamp_end' parameters must be provided.
+         *     Either the `iso_timestamp_start` and `iso_timestamp_end` parameters must be provided.
          *     If both are not provided, only the last 1 minute of logs will be queried.
          *     The timestamp range must be no more than 24 hours and is rounded to the nearest minute. If the range is more than 24 hours, a validation error will be thrown.
+         *
+         *     Note: Unless the `sql` parameter is provided, only edge_logs will be queried. See the [log query docs](/docs/guides/telemetry/logs?queryGroups=product&product=postgres&queryGroups=source&source=edge_logs#querying-with-the-logs-explorer:~:text=logs%20from%20the-,Sources,-drop%2Ddown%3A) for all available sources.
          *
          */
         get: operations["v1-get-project-logs"];
@@ -1191,6 +1294,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{ref}/analytics/endpoints/functions.combined-stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets a project's function combined statistics */
+        get: operations["v1-get-project-function-combined-stats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/cli/login-role": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** [Beta] Create a login role for CLI with temporary password */
+        post: operations["v1-create-login-role"];
+        /** [Beta] Delete existing login roles used by CLI */
+        delete: operations["v1-delete-login-roles"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{ref}/database/migrations": {
         parameters: {
             query?: never;
@@ -1213,10 +1351,38 @@ export interface paths {
          * @description Only available to selected partner OAuth apps
          */
         post: operations["v1-apply-a-migration"];
-        delete?: never;
+        /**
+         * [Beta] Rollback database migrations and remove them from history table
+         * @description Only available to selected partner OAuth apps
+         */
+        delete: operations["v1-rollback-migrations"];
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/database/migrations/{version}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * [Beta] Fetch an existing entry from migration history
+         * @description Only available to selected partner OAuth apps
+         */
+        get: operations["v1-get-a-migration"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * [Beta] Patch an existing entry in migration history
+         * @description Only available to selected partner OAuth apps
+         */
+        patch: operations["v1-patch-a-migration"];
         trace?: never;
     };
     "/v1/projects/{ref}/database/query": {
@@ -1230,6 +1396,26 @@ export interface paths {
         put?: never;
         /** [Beta] Run sql query */
         post: operations["v1-run-a-query"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/database/query/read-only": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * [Beta] Run a sql query as supabase_read_only_user
+         * @description All entity references must be schema qualified.
+         */
+        post: operations["v1-read-only-query"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1269,6 +1455,91 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/database/password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates the database password */
+        patch: operations["v1-update-database-password"];
+        trace?: never;
+    };
+    "/v1/projects/{ref}/database/jit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get user-id to role mappings for JIT access
+         * @description Mappings of roles a user can assume in the project database
+         */
+        get: operations["v1-get-jit-access"];
+        /**
+         * Updates a user mapping for JIT access
+         * @description Modifies the roles that can be assumed and for how long
+         */
+        put: operations["v1-update-jit-access"];
+        /**
+         * Authorize user-id to role mappings for JIT access
+         * @description Authorizes the request to assume a role in the project database
+         */
+        post: operations["v1-authorize-jit-access"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/database/jit/list": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all user-id to role mappings for JIT access
+         * @description Mappings of roles a user can assume in the project database
+         */
+        get: operations["v1-list-jit-access"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/database/jit/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete JIT access by user-id
+         * @description Remove JIT mappings of a user, revoking all JIT database access
+         */
+        delete: operations["v1-delete-jit-access"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1382,6 +1653,164 @@ export interface paths {
         get: operations["v1-list-all-buckets"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/disk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get database disk attributes */
+        get: operations["v1-get-database-disk"];
+        put?: never;
+        /** Modify database disk */
+        post: operations["v1-modify-database-disk"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/disk/util": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get disk utilization */
+        get: operations["v1-get-disk-utilization"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/disk/autoscale": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets project disk autoscale config */
+        get: operations["v1-get-project-disk-autoscale-config"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/storage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets project's storage config */
+        get: operations["v1-get-storage-config"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates project's storage config */
+        patch: operations["v1-update-storage-config"];
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/database/pgbouncer": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get project's pgbouncer config */
+        get: operations["v1-get-project-pgbouncer-config"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/database/pooler": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets project's supavisor config */
+        get: operations["v1-get-pooler-config"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates project's supavisor config */
+        patch: operations["v1-update-pooler-config"];
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/database/postgres": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets project's Postgres config */
+        get: operations["v1-get-postgres-config"];
+        /** Updates project's Postgres config */
+        put: operations["v1-update-postgres-config"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/realtime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets realtime configuration */
+        get: operations["v1-get-realtime-config"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates realtime configuration */
+        patch: operations["v1-update-realtime-config"];
+        trace?: never;
+    };
+    "/v1/projects/{ref}/config/realtime/shutdown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Shutdowns realtime connections for a project */
+        post: operations["v1-shutdown-realtime"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1546,6 +1975,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations/{slug}/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Gets all projects for the given organization
+         * @description Returns a paginated list of projects for the specified organization.
+         *
+         *     This endpoint uses offset-based pagination. Use the `offset` parameter to skip a number of projects and the `limit` parameter to control the number of projects returned per page.
+         */
+        get: operations["v1-get-all-projects-for-organization"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1574,8 +2025,15 @@ export interface components {
             persistent?: boolean;
             /** @enum {string} */
             status?: "CREATING_PROJECT" | "RUNNING_MIGRATIONS" | "MIGRATIONS_PASSED" | "MIGRATIONS_FAILED" | "FUNCTIONS_DEPLOYED" | "FUNCTIONS_FAILED";
+            request_review?: boolean;
+            /**
+             * Format: uri
+             * @description HTTP endpoint to receive branch status updates.
+             */
+            notify_url?: string;
         };
         BranchResponse: {
+            /** Format: uuid */
             id: string;
             name: string;
             project_ref: string;
@@ -1592,8 +2050,19 @@ export interface components {
             persistent: boolean;
             /** @enum {string} */
             status: "CREATING_PROJECT" | "RUNNING_MIGRATIONS" | "MIGRATIONS_PASSED" | "MIGRATIONS_FAILED" | "FUNCTIONS_DEPLOYED" | "FUNCTIONS_FAILED";
+            /** Format: date-time */
             created_at: string;
+            /** Format: date-time */
             updated_at: string;
+            /** Format: date-time */
+            review_requested_at?: string;
+            with_data: boolean;
+            /** Format: uri */
+            notify_url?: string;
+            /** Format: date-time */
+            deletion_scheduled_at?: string;
+            /** @enum {string} */
+            preview_project_status?: "INACTIVE" | "ACTIVE_HEALTHY" | "ACTIVE_UNHEALTHY" | "COMING_UP" | "UNKNOWN" | "GOING_DOWN" | "INIT_FAILED" | "REMOVED" | "RESTORING" | "UPGRADING" | "PAUSING" | "RESTORE_FAILED" | "RESTARTING" | "PAUSE_FAILED" | "RESIZING";
         };
         BranchDeleteResponse: {
             /** @enum {string} */
@@ -1607,11 +2076,53 @@ export interface components {
             /** @enum {string} */
             message: "ok";
         };
+        BranchRestoreResponse: {
+            /** @enum {string} */
+            message: "Branch restoration initiated";
+        };
+        V1ListProjectsPaginatedResponse: {
+            projects: {
+                id: number;
+                cloud_provider: string;
+                inserted_at: string | null;
+                name: string;
+                organization_id: number;
+                organization_slug: string;
+                ref: string;
+                region: string;
+                status: string;
+                subscription_id: string | null;
+                is_branch_enabled: boolean;
+                is_physical_backups_enabled: boolean | null;
+                preview_branch_refs: string[];
+                disk_volume_size_gb?: number;
+                /** @enum {string} */
+                infra_compute_size?: "pico" | "nano" | "micro" | "small" | "medium" | "large" | "xlarge" | "2xlarge" | "4xlarge" | "8xlarge" | "12xlarge" | "16xlarge" | "24xlarge" | "24xlarge_optimized_memory" | "24xlarge_optimized_cpu" | "24xlarge_high_memory" | "48xlarge" | "48xlarge_optimized_memory" | "48xlarge_optimized_cpu" | "48xlarge_high_memory";
+            }[];
+            pagination: {
+                /** @description Total number of projects. Use this to calculate the total number of pages. */
+                count: number;
+                /** @description Maximum number of projects per page (actual number may be less) */
+                limit: number;
+                /** @description Number of projects skipped in this response */
+                offset: number;
+            };
+        };
         V1ProjectWithDatabaseResponse: {
-            /** @description Id of your project */
+            /**
+             * @deprecated
+             * @description Deprecated: Use `ref` instead.
+             */
             id: string;
-            /** @description Slug of your organization */
+            /** @description Project ref */
+            ref: string;
+            /**
+             * @deprecated
+             * @description Deprecated: Use `organization_slug` instead.
+             */
             organization_id: string;
+            /** @description Organization slug */
+            organization_slug: string;
             /** @description Name of your project */
             name: string;
             /**
@@ -1642,8 +2153,13 @@ export interface components {
             db_pass: string;
             /** @description Name of your project */
             name: string;
-            /** @description Slug of your organization */
-            organization_id: string;
+            /**
+             * @deprecated
+             * @description Deprecated: Use `organization_slug` instead.
+             */
+            organization_id?: string;
+            /** @description Organization slug */
+            organization_slug: string;
             /**
              * @deprecated
              * @description Subscription Plan is now set on organization level and is ignored in this request
@@ -1651,17 +2167,45 @@ export interface components {
              */
             plan?: "free" | "pro";
             /**
-             * @description Region you want your server to reside in
+             * @deprecated
+             * @description Region you want your server to reside in. Use region_selection instead.
+             * @example us-east-1
              * @enum {string}
              */
-            region: "us-east-1" | "us-east-2" | "us-west-1" | "us-west-2" | "ap-east-1" | "ap-southeast-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-southeast-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "eu-north-1" | "eu-central-1" | "eu-central-2" | "ca-central-1" | "ap-south-1" | "sa-east-1";
+            region?: "us-east-1" | "us-east-2" | "us-west-1" | "us-west-2" | "ap-east-1" | "ap-southeast-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-southeast-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "eu-north-1" | "eu-central-1" | "eu-central-2" | "ca-central-1" | "ap-south-1" | "sa-east-1";
+            /**
+             * @description Region selection. Only one of region or region_selection can be specified.
+             * @example { type: 'smartGroup', code: 'americas' }
+             */
+            region_selection?: {
+                /** @enum {string} */
+                type: "specific";
+                /**
+                 * @description Specific region code. The codes supported are not a stable API, and should be retrieved from the /available-regions endpoint.
+                 * @enum {string}
+                 */
+                code: "us-east-1" | "us-east-2" | "us-west-1" | "us-west-2" | "ap-east-1" | "ap-southeast-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-southeast-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "eu-north-1" | "eu-central-1" | "eu-central-2" | "ca-central-1" | "ap-south-1" | "sa-east-1";
+            } | {
+                /** @enum {string} */
+                type: "smartGroup";
+                /**
+                 * @description The Smart Region Group's code. The codes supported are not a stable API, and should be retrieved from the /available-regions endpoint.
+                 * @example apac
+                 * @enum {string}
+                 */
+                code: "americas" | "emea" | "apac";
+            };
             /**
              * @deprecated
              * @description This field is deprecated and is ignored in this request
              */
             kps_enabled?: boolean;
-            /** @enum {string} */
-            desired_instance_size?: "pico" | "nano" | "micro" | "small" | "medium" | "large" | "xlarge" | "2xlarge" | "4xlarge" | "8xlarge" | "12xlarge" | "16xlarge" | "24xlarge" | "24xlarge_optimized_memory" | "24xlarge_optimized_cpu" | "24xlarge_high_memory" | "48xlarge" | "48xlarge_optimized_memory" | "48xlarge_optimized_cpu" | "48xlarge_high_memory";
+            /**
+             * @description Desired instance size. Omit this field to always default to the smallest possible size.
+             * @example nano
+             * @enum {string}
+             */
+            desired_instance_size?: "nano" | "micro" | "small" | "medium" | "large" | "xlarge" | "2xlarge" | "4xlarge" | "8xlarge" | "12xlarge" | "16xlarge" | "24xlarge" | "24xlarge_optimized_memory" | "24xlarge_optimized_cpu" | "24xlarge_high_memory" | "48xlarge" | "48xlarge_optimized_memory" | "48xlarge_optimized_cpu" | "48xlarge_high_memory";
             /**
              * Format: uri
              * @description Template URL used to create the project from the CLI.
@@ -1670,10 +2214,20 @@ export interface components {
             template_url?: string;
         };
         V1ProjectResponse: {
-            /** @description Id of your project */
+            /**
+             * @deprecated
+             * @description Deprecated: Use `ref` instead.
+             */
             id: string;
-            /** @description Slug of your organization */
+            /** @description Project ref */
+            ref: string;
+            /**
+             * @deprecated
+             * @description Deprecated: Use `organization_slug` instead.
+             */
             organization_id: string;
+            /** @description Organization slug */
+            organization_slug: string;
             /** @description Name of your project */
             name: string;
             /**
@@ -1689,8 +2243,55 @@ export interface components {
             /** @enum {string} */
             status: "INACTIVE" | "ACTIVE_HEALTHY" | "ACTIVE_UNHEALTHY" | "COMING_UP" | "UNKNOWN" | "GOING_DOWN" | "INIT_FAILED" | "REMOVED" | "RESTORING" | "UPGRADING" | "PAUSING" | "RESTORE_FAILED" | "RESTARTING" | "PAUSE_FAILED" | "RESIZING";
         };
+        RegionsInfo: {
+            recommendations: {
+                smartGroup: {
+                    name: string;
+                    /** @enum {string} */
+                    code: "americas" | "emea" | "apac";
+                    /** @enum {string} */
+                    type: "smartGroup";
+                };
+                specific: {
+                    name: string;
+                    /** @enum {string} */
+                    code: "us-east-1" | "us-east-2" | "us-west-1" | "us-west-2" | "ap-southeast-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-east-1" | "ap-southeast-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "eu-north-1" | "eu-central-1" | "eu-central-2" | "ca-central-1" | "ap-south-1" | "sa-east-1";
+                    /** @enum {string} */
+                    type: "specific";
+                    /** @enum {string} */
+                    provider: "AWS" | "FLY" | "AWS_K8S" | "AWS_NIMBUS";
+                    /** @enum {string} */
+                    status?: "capacity" | "other";
+                }[];
+            };
+            all: {
+                smartGroup: {
+                    name: string;
+                    /** @enum {string} */
+                    code: "americas" | "emea" | "apac";
+                    /** @enum {string} */
+                    type: "smartGroup";
+                }[];
+                specific: {
+                    name: string;
+                    /** @enum {string} */
+                    code: "us-east-1" | "us-east-2" | "us-west-1" | "us-west-2" | "ap-southeast-1" | "ap-northeast-1" | "ap-northeast-2" | "ap-east-1" | "ap-southeast-2" | "eu-west-1" | "eu-west-2" | "eu-west-3" | "eu-north-1" | "eu-central-1" | "eu-central-2" | "ca-central-1" | "ap-south-1" | "sa-east-1";
+                    /** @enum {string} */
+                    type: "specific";
+                    /** @enum {string} */
+                    provider: "AWS" | "FLY" | "AWS_K8S" | "AWS_NIMBUS";
+                    /** @enum {string} */
+                    status?: "capacity" | "other";
+                }[];
+            };
+        };
         OrganizationResponseV1: {
+            /**
+             * @deprecated
+             * @description Deprecated: Use `slug` instead.
+             */
             id: string;
+            /** @description Organization slug */
             slug: string;
             name: string;
         };
@@ -1707,6 +2308,12 @@ export interface components {
             code_verifier?: string;
             redirect_uri?: string;
             refresh_token?: string;
+            /**
+             * Format: uri
+             * @description Resource indicator for MCP (Model Context Protocol) clients
+             */
+            resource?: string;
+            scope?: string;
         };
         OAuthTokenResponse: {
             access_token: string;
@@ -1744,6 +2351,7 @@ export interface components {
                     id: number;
                     username: string;
                 };
+                favorite: boolean;
             }[];
             cursor?: string;
         };
@@ -1769,23 +2377,82 @@ export interface components {
                 id: number;
                 username: string;
             };
+            favorite: boolean;
             content: {
-                favorite: boolean;
+                /**
+                 * @deprecated
+                 * @description Deprecated: Rely on root-level favorite property instead.
+                 */
+                favorite?: boolean;
                 schema_version: string;
                 sql: string;
             };
+        };
+        ListActionRunResponse: {
+            id: string;
+            branch_id: string;
+            run_steps: {
+                /** @enum {string} */
+                name: "clone" | "pull" | "health" | "configure" | "migrate" | "seed" | "deploy";
+                /** @enum {string} */
+                status: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+                created_at: string;
+                updated_at: string;
+            }[];
+            git_config?: unknown;
+            workdir: string | null;
+            check_run_id: number | null;
+            created_at: string;
+            updated_at: string;
+        }[];
+        ActionRunResponse: {
+            id: string;
+            branch_id: string;
+            run_steps: {
+                /** @enum {string} */
+                name: "clone" | "pull" | "health" | "configure" | "migrate" | "seed" | "deploy";
+                /** @enum {string} */
+                status: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+                created_at: string;
+                updated_at: string;
+            }[];
+            git_config?: unknown;
+            workdir: string | null;
+            check_run_id: number | null;
+            created_at: string;
+            updated_at: string;
+        };
+        UpdateRunStatusBody: {
+            /** @enum {string} */
+            clone?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+            /** @enum {string} */
+            pull?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+            /** @enum {string} */
+            health?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+            /** @enum {string} */
+            configure?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+            /** @enum {string} */
+            migrate?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+            /** @enum {string} */
+            seed?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+            /** @enum {string} */
+            deploy?: "CREATED" | "DEAD" | "EXITED" | "PAUSED" | "REMOVING" | "RESTARTING" | "RUNNING";
+        };
+        UpdateRunStatusResponse: {
+            /** @enum {string} */
+            message: "ok";
         };
         ApiKeyResponse: {
             api_key?: string | null;
             id?: string | null;
             /** @enum {string|null} */
-            type?: "publishable" | "secret" | "legacy" | null;
+            type?: "legacy" | "publishable" | "secret" | null;
             prefix?: string | null;
             name: string;
             description?: string | null;
             hash?: string | null;
             secret_jwt_template?: {
-                role: string;
+                [key: string]: unknown;
             } | null;
             /** Format: date-time */
             inserted_at?: string | null;
@@ -1801,19 +2468,20 @@ export interface components {
             name: string;
             description?: string | null;
             secret_jwt_template?: {
-                role: string;
+                [key: string]: unknown;
             } | null;
         };
         UpdateApiKeyBody: {
             name?: string;
             description?: string | null;
             secret_jwt_template?: {
-                role: string;
+                [key: string]: unknown;
             } | null;
         };
         CreateBranchBody: {
             branch_name: string;
             git_branch?: string;
+            is_default?: boolean;
             persistent?: boolean;
             region?: string;
             /** @enum {string} */
@@ -1831,6 +2499,12 @@ export interface components {
             secrets?: {
                 [key: string]: string;
             };
+            with_data?: boolean;
+            /**
+             * Format: uri
+             * @description HTTP endpoint to receive branch status updates.
+             */
+            notify_url?: string;
         };
         UpdateCustomHostnameResponse: {
             /** @enum {string} */
@@ -1867,6 +2541,26 @@ export interface components {
         UpdateCustomHostnameBody: {
             custom_hostname: string;
         };
+        JitAccessResponse: {
+            /** Format: uuid */
+            user_id: string;
+            user_roles: {
+                role: string;
+                expires_at?: number;
+                allowed_networks?: {
+                    allowed_cidrs?: {
+                        cidr: string;
+                    }[];
+                    allowed_cidrs_v6?: {
+                        cidr: string;
+                    }[];
+                };
+            }[];
+        };
+        JitAccessRequestRequest: {
+            /** @enum {string} */
+            state: "enabled" | "disabled" | "unavailable";
+        };
         NetworkBanResponse: {
             banned_ipv4_addresses: string[];
         };
@@ -1878,7 +2572,13 @@ export interface components {
             }[];
         };
         RemoveNetworkBanRequest: {
+            /** @description List of IP addresses to unban. */
             ipv4_addresses: string[];
+            /**
+             * @description Include requester's public IP in the list of addresses to unban.
+             * @default false
+             */
+            requester_ip: boolean;
             identifier?: string;
         };
         NetworkRestrictionsResponse: {
@@ -1896,10 +2596,50 @@ export interface components {
             };
             /** @enum {string} */
             status: "stored" | "applied";
+            /** Format: date-time */
+            updated_at?: string;
+            /** Format: date-time */
+            applied_at?: string;
         };
         NetworkRestrictionsRequest: {
             dbAllowedCidrs?: string[];
             dbAllowedCidrsV6?: string[];
+        };
+        NetworkRestrictionsPatchRequest: {
+            add?: {
+                dbAllowedCidrs?: string[];
+                dbAllowedCidrsV6?: string[];
+            };
+            remove?: {
+                dbAllowedCidrs?: string[];
+                dbAllowedCidrsV6?: string[];
+            };
+        };
+        NetworkRestrictionsV2Response: {
+            /** @enum {string} */
+            entitlement: "disallowed" | "allowed";
+            /** @description At any given point in time, this is the config that the user has requested be applied to their project. The `status` field indicates if it has been applied to the project, or is pending. When an updated config is received, the applied config is moved to `old_config`. */
+            config: {
+                dbAllowedCidrs?: {
+                    address: string;
+                    /** @enum {string} */
+                    type: "v4" | "v6";
+                }[];
+            };
+            /** @description Populated when a new config has been received, but not registered as successfully applied to a project. */
+            old_config?: {
+                dbAllowedCidrs?: {
+                    address: string;
+                    /** @enum {string} */
+                    type: "v4" | "v6";
+                }[];
+            };
+            /** Format: date-time */
+            updated_at?: string;
+            /** Format: date-time */
+            applied_at?: string;
+            /** @enum {string} */
+            status: "stored" | "applied";
         };
         PgsodiumConfigResponse: {
             root_key: string;
@@ -1933,6 +2673,9 @@ export interface components {
             ref: string;
             name: string;
         };
+        V1UpdateProjectBody: {
+            name: string;
+        };
         SecretResponse: {
             name: string;
             value: string;
@@ -1946,6 +2689,7 @@ export interface components {
             name: string;
             value: string;
         }[];
+        DeleteSecretsBody: string[];
         SslEnforcementResponse: {
             currentConfig: {
                 database: boolean;
@@ -1990,16 +2734,71 @@ export interface components {
             latest_app_version: string;
             target_upgrade_versions: {
                 /** @enum {string} */
-                postgres_version: "15" | "17" | "17-oriole";
+                postgres_version: "13" | "14" | "15" | "17" | "17-oriole";
                 /** @enum {string} */
                 release_channel: "internal" | "alpha" | "beta" | "ga" | "withdrawn" | "preview";
                 app_version: string;
             }[];
             duration_estimate_hours: number;
             legacy_auth_custom_roles: string[];
+            /**
+             * @deprecated
+             * @description Use validation_errors instead.
+             */
             objects_to_be_dropped: string[];
+            /**
+             * @deprecated
+             * @description Use validation_errors instead.
+             */
             unsupported_extensions: string[];
+            /**
+             * @deprecated
+             * @description Use validation_errors instead.
+             */
             user_defined_objects_in_internal_schemas: string[];
+            validation_errors: ({
+                /** @enum {string} */
+                type: "objects_depending_on_pg_cron";
+                dependents: string[];
+            } | {
+                /** @enum {string} */
+                type: "indexes_referencing_ll_to_earth";
+                schema_name: string;
+                table_name: string;
+                index_name: string;
+            } | {
+                /** @enum {string} */
+                type: "function_using_obsolete_lang";
+                schema_name: string;
+                function_name: string;
+                lang_name: string;
+            } | {
+                /** @enum {string} */
+                type: "unsupported_extension";
+                extension_name: string;
+            } | {
+                /** @enum {string} */
+                type: "unsupported_fdw_handler";
+                fdw_name: string;
+                fdw_handler_name: string;
+            } | {
+                /** @enum {string} */
+                type: "unlogged_table_with_persistent_sequence";
+                schema_name: string;
+                table_name: string;
+                sequence_name: string;
+            } | {
+                /** @enum {string} */
+                type: "user_defined_objects_in_internal_schemas";
+                /** @enum {string} */
+                obj_type: "table" | "function";
+                schema_name: string;
+                obj_name: string;
+            } | {
+                /** @enum {string} */
+                type: "active_replication_slot";
+                slot_name: string;
+            })[];
         };
         DatabaseUpgradeStatusResponse: {
             databaseUpgradeStatus: {
@@ -2031,7 +2830,11 @@ export interface components {
         };
         V1ServiceHealthResponse: {
             /** @enum {string} */
-            name: "auth" | "db" | "pooler" | "realtime" | "rest" | "storage";
+            name: "auth" | "db" | "db_postgres_user" | "pooler" | "realtime" | "rest" | "storage" | "pg_bouncer";
+            /**
+             * @deprecated
+             * @description Deprecated. Use `status` instead.
+             */
             healthy: boolean;
             /** @enum {string} */
             status: "COMING_UP" | "ACTIVE_HEALTHY" | "UNHEALTHY";
@@ -2041,9 +2844,16 @@ export interface components {
                 version: string;
                 description: string;
             } | {
+                /**
+                 * @deprecated
+                 * @description Deprecated. Use `status` instead.
+                 */
                 healthy: boolean;
                 db_connected: boolean;
+                replication_connected: boolean;
                 connected_cluster: number;
+            } | {
+                db_schema: string;
             };
             error?: string;
         };
@@ -2066,8 +2876,17 @@ export interface components {
             /** @enum {string} */
             status?: "in_use" | "standby";
             private_jwk?: {
+                /** Format: uuid */
+                kid?: string;
+                /** @enum {string} */
+                use?: "sig";
+                key_ops?: ("sign" | "verify")[];
+                /** @enum {boolean} */
+                ext?: true;
                 /** @enum {string} */
                 kty: "RSA";
+                /** @enum {string} */
+                alg?: "RS256";
                 n: string;
                 /** @enum {string} */
                 e: "AQAB";
@@ -2078,23 +2897,50 @@ export interface components {
                 dq: string;
                 qi: string;
             } | {
+                /** Format: uuid */
+                kid?: string;
+                /** @enum {string} */
+                use?: "sig";
+                key_ops?: ("sign" | "verify")[];
+                /** @enum {boolean} */
+                ext?: true;
                 /** @enum {string} */
                 kty: "EC";
+                /** @enum {string} */
+                alg?: "ES256";
                 /** @enum {string} */
                 crv: "P-256";
                 x: string;
                 y: string;
                 d: string;
             } | {
+                /** Format: uuid */
+                kid?: string;
+                /** @enum {string} */
+                use?: "sig";
+                key_ops?: ("sign" | "verify")[];
+                /** @enum {boolean} */
+                ext?: true;
                 /** @enum {string} */
                 kty: "OKP";
+                /** @enum {string} */
+                alg?: "EdDSA";
                 /** @enum {string} */
                 crv: "Ed25519";
                 x: string;
                 d: string;
             } | {
+                /** Format: uuid */
+                kid?: string;
+                /** @enum {string} */
+                use?: "sig";
+                key_ops?: ("sign" | "verify")[];
+                /** @enum {boolean} */
+                ext?: true;
                 /** @enum {string} */
                 kty: "oct";
+                /** @enum {string} */
+                alg?: "HS256";
                 k: string;
             };
         };
@@ -2117,193 +2963,105 @@ export interface components {
             /** @enum {string} */
             status: "in_use" | "previously_used" | "revoked" | "standby";
         };
-        StorageConfigResponse: {
-            /** Format: int64 */
-            fileSizeLimit: number;
-            features: {
-                imageTransformation: {
-                    enabled: boolean;
-                };
-                s3Protocol: {
-                    enabled: boolean;
-                };
-            };
-        };
-        UpdateStorageConfigBody: {
-            /** Format: int64 */
-            fileSizeLimit?: number;
-            features?: {
-                imageTransformation: {
-                    enabled: boolean;
-                };
-                s3Protocol: {
-                    enabled: boolean;
-                };
-            };
-        };
-        PostgresConfigResponse: {
-            effective_cache_size?: string;
-            logical_decoding_work_mem?: string;
-            maintenance_work_mem?: string;
-            track_activity_query_size?: string;
-            max_connections?: number;
-            max_locks_per_transaction?: number;
-            max_parallel_maintenance_workers?: number;
-            max_parallel_workers?: number;
-            max_parallel_workers_per_gather?: number;
-            max_replication_slots?: number;
-            max_slot_wal_keep_size?: string;
-            max_standby_archive_delay?: string;
-            max_standby_streaming_delay?: string;
-            max_wal_size?: string;
-            max_wal_senders?: number;
-            max_worker_processes?: number;
-            /** @enum {string} */
-            session_replication_role?: "origin" | "replica" | "local";
-            shared_buffers?: string;
-            statement_timeout?: string;
-            track_commit_timestamp?: boolean;
-            wal_keep_size?: string;
-            wal_sender_timeout?: string;
-            work_mem?: string;
-        };
-        UpdatePostgresConfigBody: {
-            effective_cache_size?: string;
-            logical_decoding_work_mem?: string;
-            maintenance_work_mem?: string;
-            track_activity_query_size?: string;
-            max_connections?: number;
-            max_locks_per_transaction?: number;
-            max_parallel_maintenance_workers?: number;
-            max_parallel_workers?: number;
-            max_parallel_workers_per_gather?: number;
-            max_replication_slots?: number;
-            max_slot_wal_keep_size?: string;
-            max_standby_archive_delay?: string;
-            max_standby_streaming_delay?: string;
-            max_wal_size?: string;
-            max_wal_senders?: number;
-            max_worker_processes?: number;
-            /** @enum {string} */
-            session_replication_role?: "origin" | "replica" | "local";
-            shared_buffers?: string;
-            statement_timeout?: string;
-            track_commit_timestamp?: boolean;
-            wal_keep_size?: string;
-            wal_sender_timeout?: string;
-            work_mem?: string;
-            restart_database?: boolean;
-        };
-        V1PgbouncerConfigResponse: {
-            default_pool_size?: number;
-            ignore_startup_parameters?: string;
-            max_client_conn?: number;
-            /** @enum {string} */
-            pool_mode?: "transaction" | "session" | "statement";
-            connection_string?: string;
-        };
-        SupavisorConfigResponse: {
-            identifier: string;
-            /** @enum {string} */
-            database_type: "PRIMARY" | "READ_REPLICA";
-            is_using_scram_auth: boolean;
-            db_user: string;
-            db_host: string;
-            db_port: number;
-            db_name: string;
-            connection_string: string;
-            /** @description Use connection_string instead */
-            connectionString: string;
-            default_pool_size: number | null;
-            max_client_conn: number | null;
-            /** @enum {string} */
-            pool_mode: "transaction" | "session";
-        };
-        UpdateSupavisorConfigBody: {
-            default_pool_size?: number | null;
-            /**
-             * @description Dedicated pooler mode for the project
-             * @enum {string}
-             */
-            pool_mode?: "transaction" | "session";
-        };
-        UpdateSupavisorConfigResponse: {
-            default_pool_size: number | null;
-            pool_mode: string;
-        };
         AuthConfigResponse: {
             api_max_request_duration: number | null;
             db_max_pool_size: number | null;
+            /** @enum {string|null} */
+            db_max_pool_size_unit: "connections" | "percent" | null;
             disable_signup: boolean | null;
             external_anonymous_users_enabled: boolean | null;
             external_apple_additional_client_ids: string | null;
             external_apple_client_id: string | null;
+            external_apple_email_optional: boolean | null;
             external_apple_enabled: boolean | null;
             external_apple_secret: string | null;
             external_azure_client_id: string | null;
+            external_azure_email_optional: boolean | null;
             external_azure_enabled: boolean | null;
             external_azure_secret: string | null;
             external_azure_url: string | null;
             external_bitbucket_client_id: string | null;
+            external_bitbucket_email_optional: boolean | null;
             external_bitbucket_enabled: boolean | null;
             external_bitbucket_secret: string | null;
             external_discord_client_id: string | null;
+            external_discord_email_optional: boolean | null;
             external_discord_enabled: boolean | null;
             external_discord_secret: string | null;
             external_email_enabled: boolean | null;
             external_facebook_client_id: string | null;
+            external_facebook_email_optional: boolean | null;
             external_facebook_enabled: boolean | null;
             external_facebook_secret: string | null;
             external_figma_client_id: string | null;
+            external_figma_email_optional: boolean | null;
             external_figma_enabled: boolean | null;
             external_figma_secret: string | null;
             external_github_client_id: string | null;
+            external_github_email_optional: boolean | null;
             external_github_enabled: boolean | null;
             external_github_secret: string | null;
             external_gitlab_client_id: string | null;
+            external_gitlab_email_optional: boolean | null;
             external_gitlab_enabled: boolean | null;
             external_gitlab_secret: string | null;
             external_gitlab_url: string | null;
             external_google_additional_client_ids: string | null;
             external_google_client_id: string | null;
+            external_google_email_optional: boolean | null;
             external_google_enabled: boolean | null;
             external_google_secret: string | null;
             external_google_skip_nonce_check: boolean | null;
             external_kakao_client_id: string | null;
+            external_kakao_email_optional: boolean | null;
             external_kakao_enabled: boolean | null;
             external_kakao_secret: string | null;
             external_keycloak_client_id: string | null;
+            external_keycloak_email_optional: boolean | null;
             external_keycloak_enabled: boolean | null;
             external_keycloak_secret: string | null;
             external_keycloak_url: string | null;
             external_linkedin_oidc_client_id: string | null;
+            external_linkedin_oidc_email_optional: boolean | null;
             external_linkedin_oidc_enabled: boolean | null;
             external_linkedin_oidc_secret: string | null;
             external_slack_oidc_client_id: string | null;
+            external_slack_oidc_email_optional: boolean | null;
             external_slack_oidc_enabled: boolean | null;
             external_slack_oidc_secret: string | null;
             external_notion_client_id: string | null;
+            external_notion_email_optional: boolean | null;
             external_notion_enabled: boolean | null;
             external_notion_secret: string | null;
             external_phone_enabled: boolean | null;
             external_slack_client_id: string | null;
+            external_slack_email_optional: boolean | null;
             external_slack_enabled: boolean | null;
             external_slack_secret: string | null;
             external_spotify_client_id: string | null;
+            external_spotify_email_optional: boolean | null;
             external_spotify_enabled: boolean | null;
             external_spotify_secret: string | null;
             external_twitch_client_id: string | null;
+            external_twitch_email_optional: boolean | null;
             external_twitch_enabled: boolean | null;
             external_twitch_secret: string | null;
             external_twitter_client_id: string | null;
+            external_twitter_email_optional: boolean | null;
             external_twitter_enabled: boolean | null;
             external_twitter_secret: string | null;
+            external_x_client_id: string | null;
+            external_x_email_optional: boolean | null;
+            external_x_enabled: boolean | null;
+            external_x_secret: string | null;
             external_workos_client_id: string | null;
             external_workos_enabled: boolean | null;
             external_workos_secret: string | null;
             external_workos_url: string | null;
             external_web3_solana_enabled: boolean | null;
+            external_web3_ethereum_enabled: boolean | null;
             external_zoom_client_id: string | null;
+            external_zoom_email_optional: boolean | null;
             external_zoom_enabled: boolean | null;
             external_zoom_secret: string | null;
             hook_custom_access_token_enabled: boolean | null;
@@ -2324,6 +3082,9 @@ export interface components {
             hook_before_user_created_enabled: boolean | null;
             hook_before_user_created_uri: string | null;
             hook_before_user_created_secrets: string | null;
+            hook_after_user_created_enabled: boolean | null;
+            hook_after_user_created_uri: string | null;
+            hook_after_user_created_secrets: string | null;
             jwt_exp: number | null;
             mailer_allow_unverified_email_sign_ins: boolean | null;
             mailer_autoconfirm: boolean | null;
@@ -2336,12 +3097,33 @@ export interface components {
             mailer_subjects_magic_link: string | null;
             mailer_subjects_reauthentication: string | null;
             mailer_subjects_recovery: string | null;
+            mailer_subjects_password_changed_notification: string | null;
+            mailer_subjects_email_changed_notification: string | null;
+            mailer_subjects_phone_changed_notification: string | null;
+            mailer_subjects_mfa_factor_enrolled_notification: string | null;
+            mailer_subjects_mfa_factor_unenrolled_notification: string | null;
+            mailer_subjects_identity_linked_notification: string | null;
+            mailer_subjects_identity_unlinked_notification: string | null;
             mailer_templates_confirmation_content: string | null;
             mailer_templates_email_change_content: string | null;
             mailer_templates_invite_content: string | null;
             mailer_templates_magic_link_content: string | null;
             mailer_templates_reauthentication_content: string | null;
             mailer_templates_recovery_content: string | null;
+            mailer_templates_password_changed_notification_content: string | null;
+            mailer_templates_email_changed_notification_content: string | null;
+            mailer_templates_phone_changed_notification_content: string | null;
+            mailer_templates_mfa_factor_enrolled_notification_content: string | null;
+            mailer_templates_mfa_factor_unenrolled_notification_content: string | null;
+            mailer_templates_identity_linked_notification_content: string | null;
+            mailer_templates_identity_unlinked_notification_content: string | null;
+            mailer_notifications_password_changed_enabled: boolean | null;
+            mailer_notifications_email_changed_enabled: boolean | null;
+            mailer_notifications_phone_changed_enabled: boolean | null;
+            mailer_notifications_mfa_factor_enrolled_enabled: boolean | null;
+            mailer_notifications_mfa_factor_unenrolled_enabled: boolean | null;
+            mailer_notifications_identity_linked_enabled: boolean | null;
+            mailer_notifications_identity_unlinked_enabled: boolean | null;
             mfa_max_enrolled_factors: number | null;
             mfa_totp_enroll_enabled: boolean | null;
             mfa_totp_verify_enabled: boolean | null;
@@ -2352,6 +3134,9 @@ export interface components {
             mfa_phone_otp_length: number;
             mfa_phone_template: string | null;
             mfa_phone_max_frequency: number | null;
+            nimbus_oauth_client_id: string | null;
+            nimbus_oauth_email_optional: boolean | null;
+            nimbus_oauth_client_secret: string | null;
             password_hibp_enabled: boolean | null;
             password_min_length: number | null;
             /** @enum {string|null} */
@@ -2367,6 +3152,7 @@ export interface components {
             saml_enabled: boolean | null;
             saml_external_url: string | null;
             saml_allow_encrypted_assertions: boolean | null;
+            security_sb_forwarded_for_enabled: boolean | null;
             security_captcha_enabled: boolean | null;
             /** @enum {string|null} */
             security_captcha_provider: "turnstile" | "hcaptcha" | null;
@@ -2403,6 +3189,7 @@ export interface components {
             sms_vonage_api_key: string | null;
             sms_vonage_api_secret: string | null;
             sms_vonage_from: string | null;
+            /** Format: email */
             smtp_admin_email: string | null;
             smtp_host: string | null;
             smtp_max_frequency: number | null;
@@ -2411,11 +3198,17 @@ export interface components {
             smtp_sender_name: string | null;
             smtp_user: string | null;
             uri_allow_list: string | null;
+            oauth_server_enabled: boolean;
+            oauth_server_allow_dynamic_registration: boolean;
+            oauth_server_authorization_path: string | null;
+            custom_oauth_enabled: boolean;
+            custom_oauth_max_providers: number;
         };
         UpdateAuthConfigBody: {
             site_url?: string | null;
             disable_signup?: boolean | null;
             jwt_exp?: number | null;
+            /** Format: email */
             smtp_admin_email?: string | null;
             smtp_host?: string | null;
             smtp_port?: string | null;
@@ -2431,12 +3224,33 @@ export interface components {
             mailer_subjects_email_change?: string | null;
             mailer_subjects_magic_link?: string | null;
             mailer_subjects_reauthentication?: string | null;
+            mailer_subjects_password_changed_notification?: string | null;
+            mailer_subjects_email_changed_notification?: string | null;
+            mailer_subjects_phone_changed_notification?: string | null;
+            mailer_subjects_mfa_factor_enrolled_notification?: string | null;
+            mailer_subjects_mfa_factor_unenrolled_notification?: string | null;
+            mailer_subjects_identity_linked_notification?: string | null;
+            mailer_subjects_identity_unlinked_notification?: string | null;
             mailer_templates_invite_content?: string | null;
             mailer_templates_confirmation_content?: string | null;
             mailer_templates_recovery_content?: string | null;
             mailer_templates_email_change_content?: string | null;
             mailer_templates_magic_link_content?: string | null;
             mailer_templates_reauthentication_content?: string | null;
+            mailer_templates_password_changed_notification_content?: string | null;
+            mailer_templates_email_changed_notification_content?: string | null;
+            mailer_templates_phone_changed_notification_content?: string | null;
+            mailer_templates_mfa_factor_enrolled_notification_content?: string | null;
+            mailer_templates_mfa_factor_unenrolled_notification_content?: string | null;
+            mailer_templates_identity_linked_notification_content?: string | null;
+            mailer_templates_identity_unlinked_notification_content?: string | null;
+            mailer_notifications_password_changed_enabled?: boolean | null;
+            mailer_notifications_email_changed_enabled?: boolean | null;
+            mailer_notifications_phone_changed_enabled?: boolean | null;
+            mailer_notifications_mfa_factor_enrolled_enabled?: boolean | null;
+            mailer_notifications_mfa_factor_unenrolled_enabled?: boolean | null;
+            mailer_notifications_identity_linked_enabled?: boolean | null;
+            mailer_notifications_identity_unlinked_enabled?: boolean | null;
             mfa_max_enrolled_factors?: number | null;
             uri_allow_list?: string | null;
             external_anonymous_users_enabled?: boolean | null;
@@ -2444,6 +3258,7 @@ export interface components {
             external_phone_enabled?: boolean | null;
             saml_enabled?: boolean | null;
             saml_external_url?: string | null;
+            security_sb_forwarded_for_enabled?: boolean | null;
             security_captcha_enabled?: boolean | null;
             /** @enum {string|null} */
             security_captcha_provider?: "turnstile" | "hcaptcha" | null;
@@ -2512,75 +3327,104 @@ export interface components {
             hook_before_user_created_enabled?: boolean | null;
             hook_before_user_created_uri?: string | null;
             hook_before_user_created_secrets?: string | null;
+            hook_after_user_created_enabled?: boolean | null;
+            hook_after_user_created_uri?: string | null;
+            hook_after_user_created_secrets?: string | null;
             external_apple_enabled?: boolean | null;
             external_apple_client_id?: string | null;
+            external_apple_email_optional?: boolean | null;
             external_apple_secret?: string | null;
             external_apple_additional_client_ids?: string | null;
             external_azure_enabled?: boolean | null;
             external_azure_client_id?: string | null;
+            external_azure_email_optional?: boolean | null;
             external_azure_secret?: string | null;
             external_azure_url?: string | null;
             external_bitbucket_enabled?: boolean | null;
             external_bitbucket_client_id?: string | null;
+            external_bitbucket_email_optional?: boolean | null;
             external_bitbucket_secret?: string | null;
             external_discord_enabled?: boolean | null;
             external_discord_client_id?: string | null;
+            external_discord_email_optional?: boolean | null;
             external_discord_secret?: string | null;
             external_facebook_enabled?: boolean | null;
             external_facebook_client_id?: string | null;
+            external_facebook_email_optional?: boolean | null;
             external_facebook_secret?: string | null;
             external_figma_enabled?: boolean | null;
             external_figma_client_id?: string | null;
+            external_figma_email_optional?: boolean | null;
             external_figma_secret?: string | null;
             external_github_enabled?: boolean | null;
             external_github_client_id?: string | null;
+            external_github_email_optional?: boolean | null;
             external_github_secret?: string | null;
             external_gitlab_enabled?: boolean | null;
             external_gitlab_client_id?: string | null;
+            external_gitlab_email_optional?: boolean | null;
             external_gitlab_secret?: string | null;
             external_gitlab_url?: string | null;
             external_google_enabled?: boolean | null;
             external_google_client_id?: string | null;
+            external_google_email_optional?: boolean | null;
             external_google_secret?: string | null;
             external_google_additional_client_ids?: string | null;
             external_google_skip_nonce_check?: boolean | null;
             external_kakao_enabled?: boolean | null;
             external_kakao_client_id?: string | null;
+            external_kakao_email_optional?: boolean | null;
             external_kakao_secret?: string | null;
             external_keycloak_enabled?: boolean | null;
             external_keycloak_client_id?: string | null;
+            external_keycloak_email_optional?: boolean | null;
             external_keycloak_secret?: string | null;
             external_keycloak_url?: string | null;
             external_linkedin_oidc_enabled?: boolean | null;
             external_linkedin_oidc_client_id?: string | null;
+            external_linkedin_oidc_email_optional?: boolean | null;
             external_linkedin_oidc_secret?: string | null;
             external_slack_oidc_enabled?: boolean | null;
             external_slack_oidc_client_id?: string | null;
+            external_slack_oidc_email_optional?: boolean | null;
             external_slack_oidc_secret?: string | null;
             external_notion_enabled?: boolean | null;
             external_notion_client_id?: string | null;
+            external_notion_email_optional?: boolean | null;
             external_notion_secret?: string | null;
             external_slack_enabled?: boolean | null;
             external_slack_client_id?: string | null;
+            external_slack_email_optional?: boolean | null;
             external_slack_secret?: string | null;
             external_spotify_enabled?: boolean | null;
             external_spotify_client_id?: string | null;
+            external_spotify_email_optional?: boolean | null;
             external_spotify_secret?: string | null;
             external_twitch_enabled?: boolean | null;
             external_twitch_client_id?: string | null;
+            external_twitch_email_optional?: boolean | null;
             external_twitch_secret?: string | null;
             external_twitter_enabled?: boolean | null;
             external_twitter_client_id?: string | null;
+            external_twitter_email_optional?: boolean | null;
             external_twitter_secret?: string | null;
+            external_x_enabled?: boolean | null;
+            external_x_client_id?: string | null;
+            external_x_email_optional?: boolean | null;
+            external_x_secret?: string | null;
             external_workos_enabled?: boolean | null;
             external_workos_client_id?: string | null;
             external_workos_secret?: string | null;
             external_workos_url?: string | null;
             external_web3_solana_enabled?: boolean | null;
+            external_web3_ethereum_enabled?: boolean | null;
             external_zoom_enabled?: boolean | null;
             external_zoom_client_id?: string | null;
+            external_zoom_email_optional?: boolean | null;
             external_zoom_secret?: string | null;
             db_max_pool_size?: number | null;
+            /** @enum {string|null} */
+            db_max_pool_size_unit?: "connections" | "percent" | null;
             api_max_request_duration?: number | null;
             mfa_totp_enroll_enabled?: boolean | null;
             mfa_totp_verify_enabled?: boolean | null;
@@ -2591,6 +3435,12 @@ export interface components {
             mfa_phone_max_frequency?: number | null;
             mfa_phone_otp_length?: number | null;
             mfa_phone_template?: string | null;
+            nimbus_oauth_client_id?: string | null;
+            nimbus_oauth_client_secret?: string | null;
+            oauth_server_enabled?: boolean | null;
+            oauth_server_allow_dynamic_registration?: boolean | null;
+            oauth_server_authorization_path?: string | null;
+            custom_oauth_enabled?: boolean;
         };
         CreateThirdPartyAuthBody: {
             oidc_issuer_url?: string;
@@ -2680,7 +3530,7 @@ export interface components {
         V1ProjectAdvisorsResponse: {
             lints: {
                 /** @enum {string} */
-                name: "unindexed_foreign_keys" | "auth_users_exposed" | "auth_rls_initplan" | "no_primary_key" | "unused_index" | "multiple_permissive_policies" | "policy_exists_rls_disabled" | "rls_enabled_no_policy" | "duplicate_index" | "security_definer_view" | "function_search_path_mutable" | "rls_disabled_in_public" | "extension_in_public" | "rls_references_user_metadata" | "materialized_view_in_api" | "foreign_table_in_api" | "unsupported_reg_types" | "auth_otp_long_expiry" | "auth_otp_short_length" | "ssl_not_enforced" | "network_restrictions_not_set" | "password_requirements_min_length" | "pitr_not_enabled" | "auth_leaked_password_protection" | "auth_insufficient_mfa_options" | "auth_password_policy_missing" | "leaked_service_key" | "no_backup_admin";
+                name: "unindexed_foreign_keys" | "auth_users_exposed" | "auth_rls_initplan" | "no_primary_key" | "unused_index" | "multiple_permissive_policies" | "policy_exists_rls_disabled" | "rls_enabled_no_policy" | "duplicate_index" | "security_definer_view" | "function_search_path_mutable" | "rls_disabled_in_public" | "extension_in_public" | "rls_references_user_metadata" | "materialized_view_in_api" | "foreign_table_in_api" | "unsupported_reg_types" | "auth_otp_long_expiry" | "auth_otp_short_length" | "ssl_not_enforced" | "network_restrictions_not_set" | "password_requirements_min_length" | "pitr_not_enabled" | "auth_leaked_password_protection" | "auth_insufficient_mfa_options" | "auth_password_policy_missing" | "leaked_service_key" | "no_backup_admin" | "vulnerable_postgres_version";
                 title: string;
                 /** @enum {string} */
                 level: "ERROR" | "WARN" | "INFO";
@@ -2717,6 +3567,58 @@ export interface components {
                 status: string;
             };
         };
+        V1GetUsageApiCountResponse: {
+            result?: {
+                /** Format: date-time */
+                timestamp: string;
+                total_auth_requests: number;
+                total_realtime_requests: number;
+                total_rest_requests: number;
+                total_storage_requests: number;
+            }[];
+            error?: string | {
+                code: number;
+                errors: {
+                    domain: string;
+                    location: string;
+                    locationType: string;
+                    message: string;
+                    reason: string;
+                }[];
+                message: string;
+                status: string;
+            };
+        };
+        V1GetUsageApiRequestsCountResponse: {
+            result?: {
+                count: number;
+            }[];
+            error?: string | {
+                code: number;
+                errors: {
+                    domain: string;
+                    location: string;
+                    locationType: string;
+                    message: string;
+                    reason: string;
+                }[];
+                message: string;
+                status: string;
+            };
+        };
+        CreateRoleBody: {
+            read_only: boolean;
+        };
+        CreateRoleResponse: {
+            role: string;
+            password: string;
+            /** Format: int64 */
+            ttl_seconds: number;
+        };
+        DeleteRolesResponse: {
+            /** @enum {string} */
+            message: "ok";
+        };
         V1ListMigrationsResponse: {
             version: string;
             name?: string;
@@ -2724,14 +3626,33 @@ export interface components {
         V1CreateMigrationBody: {
             query: string;
             name?: string;
+            rollback?: string;
         };
         V1UpsertMigrationBody: {
             query: string;
             name?: string;
+            rollback?: string;
+        };
+        V1GetMigrationResponse: {
+            version: string;
+            name?: string;
+            statements?: string[];
+            rollback?: string[];
+            created_by?: string;
+            idempotency_key?: string;
+        };
+        V1PatchMigrationBody: {
+            name?: string;
+            rollback?: string;
         };
         V1RunQueryBody: {
             query: string;
+            parameters?: unknown[];
             read_only?: boolean;
+        };
+        V1ReadOnlyQueryBody: {
+            query: string;
+            parameters?: unknown[];
         };
         GetProjectDbMetadataResponse: {
             databases: ({
@@ -2744,6 +3665,66 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+        };
+        V1UpdatePasswordBody: {
+            password: string;
+        };
+        V1UpdatePasswordResponse: {
+            message: string;
+        };
+        AuthorizeJitAccessBody: {
+            role: string;
+            rhost: string;
+        };
+        JitAuthorizeAccessResponse: {
+            /** Format: uuid */
+            user_id: string;
+            user_role: {
+                role: string;
+                expires_at?: number;
+                allowed_networks?: {
+                    allowed_cidrs?: {
+                        cidr: string;
+                    }[];
+                    allowed_cidrs_v6?: {
+                        cidr: string;
+                    }[];
+                };
+            };
+        };
+        JitListAccessResponse: {
+            items: {
+                /** Format: uuid */
+                user_id: string;
+                user_roles: {
+                    role: string;
+                    expires_at?: number;
+                    allowed_networks?: {
+                        allowed_cidrs?: {
+                            cidr: string;
+                        }[];
+                        allowed_cidrs_v6?: {
+                            cidr: string;
+                        }[];
+                    };
+                }[];
+            }[];
+        };
+        UpdateJitAccessBody: {
+            /** Format: uuid */
+            user_id: string;
+            roles: {
+                role: string;
+                expires_at?: number;
+                allowed_networks?: {
+                    allowed_cidrs?: {
+                        cidr: string;
+                    }[];
+                    allowed_cidrs_v6?: {
+                        cidr: string;
+                    }[];
+                };
+            }[];
         };
         FunctionResponse: {
             id: string;
@@ -2827,6 +3808,7 @@ export interface components {
             import_map?: boolean;
             entrypoint_path?: string;
             import_map_path?: string;
+            ezbr_sha256?: string;
         };
         FunctionSlugResponse: {
             id: string;
@@ -2859,6 +3841,263 @@ export interface components {
             updated_at: string;
             public: boolean;
         };
+        DiskResponse: {
+            attributes: {
+                iops: number;
+                size_gb: number;
+                throughput_mibps?: number;
+                /** @enum {string} */
+                type: "gp3";
+            } | {
+                iops: number;
+                size_gb: number;
+                /** @enum {string} */
+                type: "io2";
+            };
+            last_modified_at?: string;
+        };
+        DiskRequestBody: {
+            attributes: {
+                iops: number;
+                size_gb: number;
+                throughput_mibps?: number;
+                /** @enum {string} */
+                type: "gp3";
+            } | {
+                iops: number;
+                size_gb: number;
+                /** @enum {string} */
+                type: "io2";
+            };
+        };
+        DiskUtilMetricsResponse: {
+            timestamp: string;
+            metrics: {
+                fs_size_bytes: number;
+                fs_avail_bytes: number;
+                fs_used_bytes: number;
+            };
+        };
+        DiskAutoscaleConfig: {
+            /** @description Growth percentage for disk autoscaling */
+            growth_percent: number | null;
+            /** @description Minimum increment size for disk autoscaling in GB */
+            min_increment_gb: number | null;
+            /** @description Maximum limit the disk size will grow to in GB */
+            max_size_gb: number | null;
+        };
+        StorageConfigResponse: {
+            /** Format: int64 */
+            fileSizeLimit: number;
+            features: {
+                imageTransformation: {
+                    enabled: boolean;
+                };
+                s3Protocol: {
+                    enabled: boolean;
+                };
+                icebergCatalog: {
+                    enabled: boolean;
+                    maxNamespaces: number;
+                    maxTables: number;
+                    maxCatalogs: number;
+                };
+                vectorBuckets: {
+                    enabled: boolean;
+                    maxBuckets: number;
+                    maxIndexes: number;
+                };
+            };
+            capabilities: {
+                list_v2: boolean;
+                iceberg_catalog: boolean;
+            };
+            external: {
+                /** @enum {string} */
+                upstreamTarget: "main" | "canary";
+            };
+            migrationVersion: string;
+            databasePoolMode: string;
+        };
+        UpdateStorageConfigBody: {
+            /** Format: int64 */
+            fileSizeLimit?: number;
+            features?: {
+                imageTransformation?: {
+                    enabled: boolean;
+                };
+                s3Protocol?: {
+                    enabled: boolean;
+                };
+                icebergCatalog?: {
+                    enabled: boolean;
+                    maxNamespaces: number;
+                    maxTables: number;
+                    maxCatalogs: number;
+                };
+                vectorBuckets?: {
+                    enabled: boolean;
+                    maxBuckets: number;
+                    maxIndexes: number;
+                };
+            };
+            external?: {
+                /** @enum {string} */
+                upstreamTarget: "main" | "canary";
+            };
+        };
+        V1PgbouncerConfigResponse: {
+            default_pool_size?: number;
+            ignore_startup_parameters?: string;
+            max_client_conn?: number;
+            /** @enum {string} */
+            pool_mode?: "transaction" | "session" | "statement";
+            connection_string?: string;
+            server_idle_timeout?: number;
+            server_lifetime?: number;
+            query_wait_timeout?: number;
+            reserve_pool_size?: number;
+        };
+        SupavisorConfigResponse: {
+            identifier: string;
+            /** @enum {string} */
+            database_type: "PRIMARY" | "READ_REPLICA";
+            is_using_scram_auth: boolean;
+            db_user: string;
+            db_host: string;
+            db_port: number;
+            db_name: string;
+            connection_string: string;
+            /** @description Use connection_string instead */
+            connectionString: string;
+            default_pool_size: number | null;
+            max_client_conn: number | null;
+            /** @enum {string} */
+            pool_mode: "transaction" | "session";
+        };
+        UpdateSupavisorConfigBody: {
+            default_pool_size?: number | null;
+            /**
+             * @description Dedicated pooler mode for the project
+             * @enum {string}
+             */
+            pool_mode?: "transaction" | "session";
+        };
+        UpdateSupavisorConfigResponse: {
+            default_pool_size: number | null;
+            pool_mode: string;
+        };
+        PostgresConfigResponse: {
+            effective_cache_size?: string;
+            logical_decoding_work_mem?: string;
+            maintenance_work_mem?: string;
+            track_activity_query_size?: string;
+            max_connections?: number;
+            max_locks_per_transaction?: number;
+            max_parallel_maintenance_workers?: number;
+            max_parallel_workers?: number;
+            max_parallel_workers_per_gather?: number;
+            max_replication_slots?: number;
+            max_slot_wal_keep_size?: string;
+            max_standby_archive_delay?: string;
+            max_standby_streaming_delay?: string;
+            max_wal_size?: string;
+            max_wal_senders?: number;
+            max_worker_processes?: number;
+            /** @enum {string} */
+            session_replication_role?: "origin" | "replica" | "local";
+            shared_buffers?: string;
+            /** @description Default unit: ms */
+            statement_timeout?: string;
+            track_commit_timestamp?: boolean;
+            wal_keep_size?: string;
+            /** @description Default unit: ms */
+            wal_sender_timeout?: string;
+            work_mem?: string;
+            /** @description Default unit: s */
+            checkpoint_timeout?: string;
+            hot_standby_feedback?: boolean;
+        };
+        UpdatePostgresConfigBody: {
+            effective_cache_size?: string;
+            logical_decoding_work_mem?: string;
+            maintenance_work_mem?: string;
+            track_activity_query_size?: string;
+            max_connections?: number;
+            max_locks_per_transaction?: number;
+            max_parallel_maintenance_workers?: number;
+            max_parallel_workers?: number;
+            max_parallel_workers_per_gather?: number;
+            max_replication_slots?: number;
+            max_slot_wal_keep_size?: string;
+            max_standby_archive_delay?: string;
+            max_standby_streaming_delay?: string;
+            max_wal_size?: string;
+            max_wal_senders?: number;
+            max_worker_processes?: number;
+            /** @enum {string} */
+            session_replication_role?: "origin" | "replica" | "local";
+            shared_buffers?: string;
+            /** @description Default unit: ms */
+            statement_timeout?: string;
+            track_commit_timestamp?: boolean;
+            wal_keep_size?: string;
+            /** @description Default unit: ms */
+            wal_sender_timeout?: string;
+            work_mem?: string;
+            /** @description Default unit: s */
+            checkpoint_timeout?: string;
+            hot_standby_feedback?: boolean;
+            restart_database?: boolean;
+        };
+        RealtimeConfigResponse: {
+            /** @description Whether to only allow private channels */
+            private_only: boolean | null;
+            /** @description Sets connection pool size for Realtime Authorization */
+            connection_pool: number | null;
+            /** @description Sets maximum number of concurrent users rate limit */
+            max_concurrent_users: number | null;
+            /** @description Sets maximum number of events per second rate per channel limit */
+            max_events_per_second: number | null;
+            /** @description Sets maximum number of bytes per second rate per channel limit */
+            max_bytes_per_second: number | null;
+            /** @description Sets maximum number of channels per client rate limit */
+            max_channels_per_client: number | null;
+            /** @description Sets maximum number of joins per second rate limit */
+            max_joins_per_second: number | null;
+            /** @description Sets maximum number of presence events per second rate limit */
+            max_presence_events_per_second: number | null;
+            /** @description Sets maximum number of payload size in KB rate limit */
+            max_payload_size_in_kb: number | null;
+            /** @description Disables the Realtime service for this project when true. Set to false to re-enable it. */
+            suspend: boolean | null;
+            /** @description Whether to enable presence */
+            presence_enabled: boolean;
+        };
+        UpdateRealtimeConfigBody: {
+            /** @description Whether to only allow private channels */
+            private_only?: boolean;
+            /** @description Sets connection pool size for Realtime Authorization */
+            connection_pool?: number;
+            /** @description Sets maximum number of concurrent users rate limit */
+            max_concurrent_users?: number;
+            /** @description Sets maximum number of events per second rate per channel limit */
+            max_events_per_second?: number;
+            /** @description Sets maximum number of bytes per second rate per channel limit */
+            max_bytes_per_second?: number;
+            /** @description Sets maximum number of channels per client rate limit */
+            max_channels_per_client?: number;
+            /** @description Sets maximum number of joins per second rate limit */
+            max_joins_per_second?: number;
+            /** @description Sets maximum number of presence events per second rate limit */
+            max_presence_events_per_second?: number;
+            /** @description Sets maximum number of payload size in KB rate limit */
+            max_payload_size_in_kb?: number;
+            /** @description Disables the Realtime service for this project when true. Set to false to re-enable it. */
+            suspend?: boolean;
+            /** @description Whether to enable presence */
+            presence_enabled?: boolean;
+        };
         CreateProviderBody: {
             /**
              * @description What type of provider will be created
@@ -2878,6 +4117,8 @@ export interface components {
                     };
                 };
             };
+            /** @enum {string} */
+            name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
         };
         CreateProviderResponse: {
             id: string;
@@ -2896,6 +4137,8 @@ export interface components {
                         };
                     };
                 };
+                /** @enum {string} */
+                name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
             };
             domains?: {
                 id: string;
@@ -2924,6 +4167,8 @@ export interface components {
                             };
                         };
                     };
+                    /** @enum {string} */
+                    name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
                 };
                 domains?: {
                     id: string;
@@ -2952,6 +4197,8 @@ export interface components {
                         };
                     };
                 };
+                /** @enum {string} */
+                name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
             };
             domains?: {
                 id: string;
@@ -2976,6 +4223,8 @@ export interface components {
                     };
                 };
             };
+            /** @enum {string} */
+            name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
         };
         UpdateProviderResponse: {
             id: string;
@@ -2994,6 +4243,8 @@ export interface components {
                         };
                     };
                 };
+                /** @enum {string} */
+                name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
             };
             domains?: {
                 id: string;
@@ -3021,6 +4272,8 @@ export interface components {
                         };
                     };
                 };
+                /** @enum {string} */
+                name_id_format?: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" | "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" | "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress" | "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent";
             };
             domains?: {
                 id: string;
@@ -3056,7 +4309,7 @@ export interface components {
         V1RestorePointResponse: {
             name: string;
             /** @enum {string} */
-            status: "AVAILABLE" | "PENDING" | "REMOVED";
+            status: "AVAILABLE" | "PENDING" | "REMOVED" | "FAILED";
         };
         V1UndoBody: {
             name: string;
@@ -3072,7 +4325,7 @@ export interface components {
             id: string;
             name: string;
             /** @enum {string} */
-            plan?: "free" | "pro" | "team" | "enterprise";
+            plan?: "free" | "pro" | "team" | "enterprise" | "platform";
             opt_in_tags: ("AI_SQL_GENERATOR_OPT_IN" | "AI_DATA_GENERATOR_OPT_IN" | "AI_LOG_GENERATOR_OPT_IN")[];
             allowed_release_channels: ("internal" | "alpha" | "beta" | "ga" | "withdrawn" | "preview")[];
         };
@@ -3099,17 +4352,51 @@ export interface components {
                     name: string;
                     limit: number;
                 }[];
-                target_organization_eligible: boolean | null;
-                target_organization_has_free_project_slots: boolean | null;
                 /** @enum {string} */
-                source_subscription_plan: "free" | "pro" | "team" | "enterprise";
+                source_subscription_plan: "free" | "pro" | "team" | "enterprise" | "platform";
                 /** @enum {string|null} */
-                target_subscription_plan: "free" | "pro" | "team" | "enterprise" | null;
+                target_subscription_plan: "free" | "pro" | "team" | "enterprise" | "platform" | null;
             };
             expires_at: string;
             created_at: string;
             /** Format: uuid */
             created_by: string;
+        };
+        OrganizationProjectsResponse: {
+            projects: {
+                ref: string;
+                name: string;
+                cloud_provider: string;
+                region: string;
+                is_branch: boolean;
+                /** @enum {string} */
+                status: "INACTIVE" | "ACTIVE_HEALTHY" | "ACTIVE_UNHEALTHY" | "COMING_UP" | "UNKNOWN" | "GOING_DOWN" | "INIT_FAILED" | "REMOVED" | "RESTORING" | "UPGRADING" | "PAUSING" | "RESTORE_FAILED" | "RESTARTING" | "PAUSE_FAILED" | "RESIZING";
+                inserted_at: string;
+                databases: {
+                    /** @enum {string} */
+                    infra_compute_size?: "pico" | "nano" | "micro" | "small" | "medium" | "large" | "xlarge" | "2xlarge" | "4xlarge" | "8xlarge" | "12xlarge" | "16xlarge" | "24xlarge" | "24xlarge_optimized_memory" | "24xlarge_optimized_cpu" | "24xlarge_high_memory" | "48xlarge" | "48xlarge_optimized_memory" | "48xlarge_optimized_cpu" | "48xlarge_high_memory";
+                    region: string;
+                    /** @enum {string} */
+                    status: "ACTIVE_HEALTHY" | "ACTIVE_UNHEALTHY" | "COMING_UP" | "GOING_DOWN" | "INIT_FAILED" | "REMOVED" | "RESTORING" | "UNKNOWN" | "INIT_READ_REPLICA" | "INIT_READ_REPLICA_FAILED" | "RESTARTING" | "RESIZING";
+                    cloud_provider: string;
+                    identifier: string;
+                    /** @enum {string} */
+                    type: "PRIMARY" | "READ_REPLICA";
+                    disk_volume_size_gb?: number;
+                    /** @enum {string} */
+                    disk_type?: "gp3" | "io2";
+                    disk_throughput_mbps?: number;
+                    disk_last_modified_at?: string;
+                }[];
+            }[];
+            pagination: {
+                /** @description Total number of projects. Use this to calculate the total number of pages. */
+                count: number;
+                /** @description Maximum number of projects per page */
+                limit: number;
+                /** @description Number of projects skipped in this response */
+                offset: number;
+            };
         };
     };
     responses: never;
@@ -3126,7 +4413,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3151,11 +4438,14 @@ export interface operations {
     };
     "v1-delete-a-branch": {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description If set to false, schedule deletion with 1-hour grace period (only when soft deletion is enabled). */
+                force?: boolean;
+            };
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3184,7 +4474,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3217,7 +4507,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3250,7 +4540,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3283,7 +4573,7 @@ export interface operations {
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3310,15 +4600,46 @@ export interface operations {
             };
         };
     };
+    "v1-restore-a-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Branch ID */
+                branch_id_or_ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BranchRestoreResponse"];
+                };
+            };
+            /** @description Failed to restore database branch */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     "v1-diff-a-branch": {
         parameters: {
             query?: {
                 included_schemas?: string;
+                /** @description Use pg-delta instead of Migra for diffing when true */
+                pgdelta?: boolean;
             };
             header?: never;
             path: {
                 /** @description Branch ID */
-                branch_id: string;
+                branch_id_or_ref: string;
             };
             cookie?: never;
         };
@@ -3379,6 +4700,32 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["V1ProjectResponse"];
+                };
+            };
+        };
+    };
+    "v1-get-available-regions": {
+        parameters: {
+            query: {
+                /** @description Slug of your organization */
+                organization_slug: string;
+                /** @description Continent code to determine regional recommendations: NA (North America), SA (South America), EU (Europe), AF (Africa), AS (Asia), OC (Oceania), AN (Antarctica) */
+                continent?: "NA" | "SA" | "EU" | "AF" | "AS" | "OC" | "AN";
+                /** @description Desired instance size. Omit this field to always default to the smallest possible size. */
+                desired_instance_size?: "nano" | "micro" | "small" | "medium" | "large" | "xlarge" | "2xlarge" | "4xlarge" | "8xlarge" | "12xlarge" | "16xlarge" | "24xlarge" | "24xlarge_optimized_memory" | "24xlarge_optimized_cpu" | "24xlarge_high_memory" | "48xlarge" | "48xlarge_optimized_memory" | "48xlarge_optimized_cpu" | "48xlarge_high_memory";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegionsInfo"];
                 };
             };
         };
@@ -3450,6 +4797,10 @@ export interface operations {
                 response_mode?: string;
                 code_challenge?: string;
                 code_challenge_method?: "plain" | "sha256" | "S256";
+                /** @description Organization slug */
+                organization_slug?: string;
+                /** @description Resource indicator for MCP (Model Context Protocol) clients */
+                resource?: string;
             };
             header?: never;
             path?: never;
@@ -3597,6 +4948,269 @@ export interface operations {
             };
         };
     };
+    "v1-list-action-runs": {
+        parameters: {
+            query?: {
+                offset?: number;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListActionRunResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to list action runs */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-count-action-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    /** @description total count value */
+                    "X-Total-Count"?: number;
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to count action runs */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-action-run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                /** @description Action Run ID */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionRunResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get action run status */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-action-run-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                /** @description Action Run ID */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateRunStatusBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateRunStatusResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update action run status */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-action-run-logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                /** @description Action Run ID */
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get action run logs */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     "v1-get-project-api-keys": {
         parameters: {
             query?: {
@@ -3620,7 +5234,22 @@ export interface operations {
                     "application/json": components["schemas"]["ApiKeyResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3655,7 +5284,22 @@ export interface operations {
                     "application/json": components["schemas"]["ApiKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3683,7 +5327,22 @@ export interface operations {
                     "application/json": components["schemas"]["LegacyApiKeysResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3714,7 +5373,22 @@ export interface operations {
                     "application/json": components["schemas"]["LegacyApiKeysResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3746,7 +5420,22 @@ export interface operations {
                     "application/json": components["schemas"]["ApiKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3781,7 +5470,22 @@ export interface operations {
                     "application/json": components["schemas"]["ApiKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3817,7 +5521,22 @@ export interface operations {
                     "application/json": components["schemas"]["ApiKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3845,7 +5564,22 @@ export interface operations {
                     "application/json": components["schemas"]["BranchResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3884,7 +5618,22 @@ export interface operations {
                     "application/json": components["schemas"]["BranchResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3917,13 +5666,79 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Failed to disable preview branching */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-a-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BranchResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to fetch database branch */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -3952,7 +5767,22 @@ export interface operations {
                     "application/json": components["schemas"]["UpdateCustomHostnameResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3985,7 +5815,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4024,7 +5869,22 @@ export interface operations {
                     "application/json": components["schemas"]["UpdateCustomHostnameResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4059,7 +5919,22 @@ export interface operations {
                     "application/json": components["schemas"]["UpdateCustomHostnameResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4094,13 +5969,132 @@ export interface operations {
                     "application/json": components["schemas"]["UpdateCustomHostnameResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Failed to activate project custom hostname configuration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-jit-access-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JitAccessResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to retrieve project's JIT access config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-jit-access-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JitAccessRequestRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JitAccessResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update project's just-in-time access configuration. */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -4129,7 +6123,22 @@ export interface operations {
                     "application/json": components["schemas"]["NetworkBanResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4164,7 +6173,22 @@ export interface operations {
                     "application/json": components["schemas"]["NetworkBanResponseEnriched"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4201,7 +6225,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4236,13 +6275,82 @@ export interface operations {
                     "application/json": components["schemas"]["NetworkRestrictionsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Failed to retrieve project's network restrictions */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-patch-network-restrictions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NetworkRestrictionsPatchRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NetworkRestrictionsV2Response"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update project network restrictions */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -4275,7 +6383,22 @@ export interface operations {
                     "application/json": components["schemas"]["NetworkRestrictionsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4310,7 +6433,22 @@ export interface operations {
                     "application/json": components["schemas"]["PgsodiumConfigResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4349,7 +6487,22 @@ export interface operations {
                     "application/json": components["schemas"]["PgsodiumConfigResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4384,7 +6537,22 @@ export interface operations {
                     "application/json": components["schemas"]["PostgrestConfigWithJWTSecretResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4423,7 +6591,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1PostgrestConfigResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4458,7 +6641,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1ProjectWithDatabaseResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4493,7 +6691,76 @@ export interface operations {
                     "application/json": components["schemas"]["V1ProjectRefResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-a-project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V1UpdateProjectBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V1ProjectRefResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update project */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4521,7 +6788,22 @@ export interface operations {
                     "application/json": components["schemas"]["SecretResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4558,7 +6840,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4585,7 +6882,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": string[];
+                "application/json": components["schemas"]["DeleteSecretsBody"];
             };
         };
         responses: {
@@ -4595,7 +6892,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4630,7 +6942,22 @@ export interface operations {
                     "application/json": components["schemas"]["SslEnforcementResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4669,7 +6996,22 @@ export interface operations {
                     "application/json": components["schemas"]["SslEnforcementResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4706,7 +7048,22 @@ export interface operations {
                     "application/json": components["schemas"]["TypescriptResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4741,7 +7098,22 @@ export interface operations {
                     "application/json": components["schemas"]["VanitySubdomainConfigResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4774,7 +7146,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4813,7 +7200,22 @@ export interface operations {
                     "application/json": components["schemas"]["SubdomainAvailabilityResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4852,7 +7254,22 @@ export interface operations {
                     "application/json": components["schemas"]["ActivateVanitySubdomainResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4891,7 +7308,22 @@ export interface operations {
                     "application/json": components["schemas"]["ProjectUpgradeInitiateResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4926,7 +7358,22 @@ export interface operations {
                     "application/json": components["schemas"]["ProjectUpgradeEligibilityResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4963,7 +7410,22 @@ export interface operations {
                     "application/json": components["schemas"]["DatabaseUpgradeStatusResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -4998,7 +7460,22 @@ export interface operations {
                     "application/json": components["schemas"]["ReadOnlyStatusResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5031,7 +7508,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5068,7 +7560,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5105,7 +7612,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5123,7 +7645,7 @@ export interface operations {
     "v1-get-services-health": {
         parameters: {
             query: {
-                services: ("auth" | "db" | "pooler" | "realtime" | "rest" | "storage")[];
+                services: ("auth" | "db" | "db_postgres_user" | "pooler" | "realtime" | "rest" | "storage" | "pg_bouncer")[];
                 timeout_ms?: number;
             };
             header?: never;
@@ -5143,7 +7665,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1ServiceHealthResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5178,7 +7715,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5206,7 +7758,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5234,7 +7801,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeysResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5266,7 +7848,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5295,7 +7892,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5324,7 +7936,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5357,256 +7984,22 @@ export interface operations {
                     "application/json": components["schemas"]["SigningKeyResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
-        };
-    };
-    "v1-get-storage-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StorageConfigResponse"];
-                };
-            };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Failed to retrieve project's storage config */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    "v1-update-storage-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateStorageConfigBody"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Failed to update project's storage config */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    "v1-get-postgres-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PostgresConfigResponse"];
-                };
-            };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Failed to retrieve project's Postgres config */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    "v1-update-postgres-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdatePostgresConfigBody"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PostgresConfigResponse"];
-                };
-            };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Failed to update project's Postgres config */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    "v1-get-project-pgbouncer-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["V1PgbouncerConfigResponse"];
-                };
-            };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Failed to retrieve project's pgbouncer config */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    "v1-get-pooler-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SupavisorConfigResponse"][];
-                };
-            };
-            /** @description Failed to retrieve project's supavisor config */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    "v1-update-pooler-config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Project ref */
-                ref: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateSupavisorConfigBody"];
-            };
-        };
-        responses: {
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UpdateSupavisorConfigResponse"];
-                };
-            };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Failed to update project's supavisor config */
-            500: {
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5634,7 +8027,22 @@ export interface operations {
                     "application/json": components["schemas"]["AuthConfigResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5673,7 +8081,22 @@ export interface operations {
                     "application/json": components["schemas"]["AuthConfigResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5708,7 +8131,22 @@ export interface operations {
                     "application/json": components["schemas"]["ThirdPartyAuth"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5740,7 +8178,22 @@ export interface operations {
                     "application/json": components["schemas"]["ThirdPartyAuth"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5769,7 +8222,22 @@ export interface operations {
                     "application/json": components["schemas"]["ThirdPartyAuth"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5798,7 +8266,22 @@ export interface operations {
                     "application/json": components["schemas"]["ThirdPartyAuth"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5824,7 +8307,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5852,7 +8350,22 @@ export interface operations {
                     "application/json": components["schemas"]["GetProjectAvailableRestoreVersionsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5878,7 +8391,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5904,7 +8432,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5932,7 +8475,22 @@ export interface operations {
                     "application/json": components["schemas"]["ListProjectAddonsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5969,7 +8527,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5991,7 +8564,7 @@ export interface operations {
             path: {
                 /** @description Project ref */
                 ref: string;
-                addon_variant: unknown;
+                addon_variant: ("ci_micro" | "ci_small" | "ci_medium" | "ci_large" | "ci_xlarge" | "ci_2xlarge" | "ci_4xlarge" | "ci_8xlarge" | "ci_12xlarge" | "ci_16xlarge" | "ci_24xlarge" | "ci_24xlarge_optimized_cpu" | "ci_24xlarge_optimized_memory" | "ci_24xlarge_high_memory" | "ci_48xlarge" | "ci_48xlarge_optimized_cpu" | "ci_48xlarge_optimized_memory" | "ci_48xlarge_high_memory") | "cd_default" | ("pitr_7" | "pitr_14" | "pitr_28") | "ipv4_default";
             };
             cookie?: never;
         };
@@ -6003,7 +8576,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6038,7 +8626,22 @@ export interface operations {
                     "application/json": components["schemas"]["ProjectClaimTokenResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6066,7 +8669,22 @@ export interface operations {
                     "application/json": components["schemas"]["CreateProjectClaimTokenResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6092,7 +8710,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6120,7 +8753,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1ProjectAdvisorsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6150,7 +8798,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1ProjectAdvisorsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6161,6 +8824,7 @@ export interface operations {
     "v1-get-project-logs": {
         parameters: {
             query?: {
+                /** @description Custom SQL query to execute on the logs. See [querying logs](/docs/guides/telemetry/logs?queryGroups=product&product=postgres&queryGroups=source&source=edge_logs#querying-with-the-logs-explorer) for more details. */
                 sql?: string;
                 iso_timestamp_start?: string;
                 iso_timestamp_end?: string;
@@ -6182,7 +8846,22 @@ export interface operations {
                     "application/json": components["schemas"]["AnalyticsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6209,10 +8888,25 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AnalyticsResponse"];
+                    "application/json": components["schemas"]["V1GetUsageApiCountResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6244,10 +8938,188 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    "application/json": components["schemas"]["V1GetUsageApiRequestsCountResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get project's usage api requests count */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-project-function-combined-stats": {
+        parameters: {
+            query: {
+                interval: "15min" | "1hr" | "3hr" | "1day";
+                function_id: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
                     "application/json": components["schemas"]["AnalyticsResponse"];
                 };
             };
-            /** @description Failed to get project's usage api requests count */
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get project's function combined statistics */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-create-login-role": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRoleBody"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateRoleResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to create login role */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-delete-login-roles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteRolesResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to delete login roles */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -6276,7 +9148,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1ListMigrationsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6316,7 +9203,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6356,13 +9258,183 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Failed to apply database migration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-rollback-migrations": {
+        parameters: {
+            query: {
+                /** @description Rollback migrations greater or equal to this version */
+                gte: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to rollback database migration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-a-migration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V1GetMigrationResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get database migration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-patch-a-migration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                version: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V1PatchMigrationBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to patch database migration */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -6393,13 +9465,80 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Failed to run sql query */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-read-only-query": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V1ReadOnlyQueryBody"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to run read-only sql query */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -6426,7 +9565,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6461,7 +9615,333 @@ export interface operations {
                     "application/json": components["schemas"]["GetProjectDbMetadataResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-database-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V1UpdatePasswordBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V1UpdatePasswordResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update database password */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-jit-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JitAccessResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to list database jit access */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-jit-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateJitAccessBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JitAccessResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to upsert database migration */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-authorize-jit-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthorizeJitAccessBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JitAuthorizeAccessResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to authorize database jit access */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-list-jit-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JitListAccessResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to list database jit access */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-delete-jit-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to remove JIT access */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6489,7 +9969,22 @@ export interface operations {
                     "application/json": components["schemas"]["FunctionResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6528,7 +10023,29 @@ export interface operations {
                     "application/json": components["schemas"]["BulkUpdateFunctionResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Maximum number of functions reached for Plan */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6578,7 +10095,29 @@ export interface operations {
                     "application/json": components["schemas"]["FunctionResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Maximum number of functions reached for Plan */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6621,7 +10160,29 @@ export interface operations {
                     "application/json": components["schemas"]["DeployFunctionResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Maximum number of functions reached for Plan */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6658,7 +10219,22 @@ export interface operations {
                     "application/json": components["schemas"]["FunctionSlugResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6693,7 +10269,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6745,7 +10336,22 @@ export interface operations {
                     "application/json": components["schemas"]["FunctionResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6782,7 +10388,22 @@ export interface operations {
                     "application/json": components["schemas"]["StreamableFile"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6817,7 +10438,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1StorageBucketResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6825,6 +10461,706 @@ export interface operations {
             };
             /** @description Failed to get list of buckets */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-database-disk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiskResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get database disk attributes */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-modify-database-disk": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DiskRequestBody"];
+            };
+        };
+        responses: {
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to modify database disk */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-disk-utilization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiskUtilMetricsResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get disk utilization */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-project-disk-autoscale-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiskAutoscaleConfig"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to get project disk autoscale config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-storage-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StorageConfigResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to retrieve project's storage config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-storage-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateStorageConfigBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update project's storage config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-project-pgbouncer-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V1PgbouncerConfigResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to retrieve project's pgbouncer config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-pooler-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SupavisorConfigResponse"][];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to retrieve project's supavisor config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-pooler-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSupavisorConfigBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateSupavisorConfigResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update project's supavisor config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-postgres-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PostgresConfigResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to retrieve project's Postgres config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-postgres-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePostgresConfigBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PostgresConfigResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update project's Postgres config */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-realtime-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Gets project's realtime configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RealtimeConfigResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-realtime-config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateRealtimeConfigBody"];
+            };
+        };
+        responses: {
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-shutdown-realtime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Realtime connections shutdown successfully */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Tenant not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6852,6 +11188,14 @@ export interface operations {
                     "application/json": components["schemas"]["ListProvidersResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6860,6 +11204,13 @@ export interface operations {
             };
             /** @description SAML 2.0 support is not enabled for this project */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6891,6 +11242,14 @@ export interface operations {
                     "application/json": components["schemas"]["CreateProviderResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6899,6 +11258,13 @@ export interface operations {
             };
             /** @description SAML 2.0 support is not enabled for this project */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6927,6 +11293,14 @@ export interface operations {
                     "application/json": components["schemas"]["GetProviderResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6935,6 +11309,13 @@ export interface operations {
             };
             /** @description Either SAML 2.0 was not enabled for this project, or the provider does not exist */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -6967,6 +11348,14 @@ export interface operations {
                     "application/json": components["schemas"]["UpdateProviderResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -6975,6 +11364,13 @@ export interface operations {
             };
             /** @description Either SAML 2.0 was not enabled for this project, or the provider does not exist */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7003,6 +11399,14 @@ export interface operations {
                     "application/json": components["schemas"]["DeleteProviderResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -7011,6 +11415,13 @@ export interface operations {
             };
             /** @description Either SAML 2.0 was not enabled for this project, or the provider does not exist */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7038,7 +11449,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1BackupsResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7075,7 +11501,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7105,7 +11546,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1RestorePointResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7144,6 +11600,27 @@ export interface operations {
                     "application/json": components["schemas"]["V1RestorePointResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     "v1-undo": {
@@ -7168,7 +11645,22 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7196,12 +11688,6 @@ export interface operations {
                     "application/json": components["schemas"]["V1OrganizationMemberResponse"][];
                 };
             };
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
         };
     };
     "v1-get-an-organization": {
@@ -7224,7 +11710,22 @@ export interface operations {
                     "application/json": components["schemas"]["V1OrganizationSlugResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7253,7 +11754,22 @@ export interface operations {
                     "application/json": components["schemas"]["OrganizationProjectClaimResponse"];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7280,7 +11796,64 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-all-projects-for-organization": {
+        parameters: {
+            query?: {
+                /** @description Number of projects to skip */
+                offset?: number;
+                /** @description Number of projects to return per page */
+                limit?: number;
+                /** @description Search projects by name */
+                search?: string;
+                /** @description Sort order for projects */
+                sort?: "name_asc" | "name_desc" | "created_asc" | "created_desc";
+                /** @description A comma-separated list of project statuses to filter by.
+                 *
+                 *     The following values are supported: `ACTIVE_HEALTHY`, `INACTIVE`. */
+                statuses?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Organization slug */
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationProjectsResponse"];
+                };
+            };
+            /** @description Failed to retrieve projects */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -124,7 +124,7 @@ export function createSupabaseApiPlatform(
         body: {
           name,
           region,
-          organization_id,
+          organization_slug: organization_id,
           db_pass:
             db_pass ??
             generatePassword({
@@ -649,11 +649,11 @@ export function createSupabaseApiPlatform(
     },
     async deleteBranch(branchId: string) {
       const response = await managementApiClient.DELETE(
-        '/v1/branches/{branch_id}',
+        '/v1/branches/{branch_id_or_ref}',
         {
           params: {
             path: {
-              branch_id: branchId,
+              branch_id_or_ref: branchId,
             },
           },
         }
@@ -663,11 +663,11 @@ export function createSupabaseApiPlatform(
     },
     async mergeBranch(branchId: string) {
       const response = await managementApiClient.POST(
-        '/v1/branches/{branch_id}/merge',
+        '/v1/branches/{branch_id_or_ref}/merge',
         {
           params: {
             path: {
-              branch_id: branchId,
+              branch_id_or_ref: branchId,
             },
           },
           body: {},
@@ -680,11 +680,11 @@ export function createSupabaseApiPlatform(
       const { migration_version } = resetBranchOptionsSchema.parse(options);
 
       const response = await managementApiClient.POST(
-        '/v1/branches/{branch_id}/reset',
+        '/v1/branches/{branch_id_or_ref}/reset',
         {
           params: {
             path: {
-              branch_id: branchId,
+              branch_id_or_ref: branchId,
             },
           },
           body: {
@@ -697,11 +697,11 @@ export function createSupabaseApiPlatform(
     },
     async rebaseBranch(branchId: string) {
       const response = await managementApiClient.POST(
-        '/v1/branches/{branch_id}/push',
+        '/v1/branches/{branch_id_or_ref}/push',
         {
           params: {
             path: {
-              branch_id: branchId,
+              branch_id_or_ref: branchId,
             },
           },
           body: {},

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -186,7 +186,7 @@ export type DatabaseOperations = {
 };
 
 export type AccountOperations = {
-  listOrganizations(): Promise<Pick<Organization, 'id' | 'name'>[]>;
+  listOrganizations(): Promise<{ id: string; slug: string; name: string }[]>;
   getOrganization(organizationId: string): Promise<Organization>;
   listProjects(): Promise<Project[]>;
   getProject(projectId: string): Promise<Project>;

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -33,7 +33,9 @@ export const organizationSchema = z.object({
 
 export const projectSchema = z.object({
   id: z.string(),
+  ref: z.string(),
   organization_id: z.string(),
+  organization_slug: z.string(),
   name: z.string(),
   status: z.string(),
   created_at: z.string(),

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -395,11 +395,13 @@ describe('tools', () => {
       arguments: newProject,
     });
 
-    const { confirm_cost_id: _, ...projectInfo } = newProject;
-
     expect(result).toEqual({
-      ...projectInfo,
       id: expect.stringMatching(/^.+$/),
+      ref: expect.stringMatching(/^.+$/),
+      name: newProject.name,
+      region: newProject.region,
+      organization_id: newProject.organization_id,
+      organization_slug: newProject.organization_id,
       created_at: expect.stringMatching(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/
       ),
@@ -2099,6 +2101,7 @@ describe('tools', () => {
       parent_project_ref: project.id,
       is_default: false,
       persistent: false,
+      with_data: false,
       status: 'CREATING_PROJECT',
       created_at: expect.stringMatching(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -152,8 +152,8 @@ describe('tools', () => {
 
     expect(result).toEqual({
       organizations: [
-        { id: org1.id, name: org1.name },
-        { id: org2.id, name: org2.name },
+        { id: org1.id, slug: org1.slug, name: org1.name },
+        { id: org2.id, slug: org2.slug, name: org2.name },
       ],
     });
   });

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -18,6 +18,7 @@ const listOrganizationsOutputSchema = z.object({
   organizations: z.array(
     z.object({
       id: z.string(),
+      slug: z.string(),
       name: z.string(),
     })
   ),

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -189,16 +189,16 @@ export const mockManagementApi = [
     const bodySchema = z.object({
       name: z.string(),
       region: z.string(),
-      organization_id: z.string(),
+      organization_slug: z.string(),
       db_pass: z.string(),
     });
     const body = await request.json();
-    const { name, region, organization_id } = bodySchema.parse(body);
+    const { name, region, organization_slug } = bodySchema.parse(body);
 
     const project = await createProject({
       name,
       region,
-      organization_id,
+      organization_id: organization_slug,
     });
 
     const { database, ...projectResponse } = project.details;
@@ -1161,7 +1161,9 @@ export type MockProjectOptions = {
 
 export class MockProject {
   id: string;
+  ref: string;
   organization_id: string;
+  organization_slug: string;
   name: string;
   region: string;
   created_at: Date;
@@ -1196,7 +1198,9 @@ export class MockProject {
   get details(): Project {
     return {
       id: this.id,
+      ref: this.ref,
       organization_id: this.organization_id,
+      organization_slug: this.organization_slug,
       name: this.name,
       region: this.region,
       created_at: this.created_at.toISOString(),
@@ -1207,10 +1211,12 @@ export class MockProject {
 
   constructor({ name, region, organization_id }: MockProjectOptions) {
     this.id = nanoid();
+    this.ref = this.id;
 
     this.name = name;
     this.region = region;
     this.organization_id = organization_id;
+    this.organization_slug = organization_id;
 
     this.created_at = new Date();
     this.status = 'UNKNOWN';
@@ -1308,6 +1314,7 @@ export class MockBranch {
       parent_project_ref: this.parent_project_ref,
       is_default: this.is_default,
       persistent: this.persistent,
+      with_data: false,
       status: this.status,
       created_at: this.created_at.toISOString(),
       updated_at: this.updated_at.toISOString(),

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -80,7 +80,7 @@ export type Migration = {
   query: string;
 };
 
-export const mockOrgs = new Map<string, Organization>();
+export const mockOrgs = new Map<string, MockOrganization>();
 export const mockProjects = new Map<string, MockProject>();
 export const mockBranches = new Map<string, MockBranch>();
 
@@ -247,7 +247,11 @@ export const mockManagementApi = [
    */
   http.get(`${API_URL}/v1/organizations`, () => {
     return HttpResponse.json(
-      Array.from(mockOrgs.values()).map(({ id, name }) => ({ id, name }))
+      Array.from(mockOrgs.values()).map(({ id, slug, name }) => ({
+        id,
+        slug,
+        name,
+      }))
     );
   }),
 
@@ -999,6 +1003,7 @@ export type MockOrganizationOptions = {
 
 export class MockOrganization {
   id: string;
+  slug: string;
   name: Organization['name'];
   plan: Organization['plan'];
   allowed_release_channels: Organization['allowed_release_channels'];
@@ -1016,6 +1021,7 @@ export class MockOrganization {
 
   constructor(options: MockOrganizationOptions) {
     this.id = nanoid();
+    this.slug = nanoid();
     this.name = options.name;
     this.plan = options.plan;
     this.allowed_release_channels = options.allowed_release_channels;

--- a/packages/mcp-server-supabase/vitest.config.ts
+++ b/packages/mcp-server-supabase/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     testTimeout: 30_000, // PGlite can take a while to initialize
     coverage: {
       reporter: ['text', 'lcov'],
-      reportsDirectory: 'test/coverage',
       include: ['src/**/*.{ts,tsx}'],
       exclude: [...configDefaults.coverage.exclude!, 'src/transports/stdio.ts'],
     },


### PR DESCRIPTION
- Regenerates `management-api/types.ts` from the live spec (was stale)
- Adds `slug` to `list_organizations` output schema (`id` is now deprecated in favor of `slug`)
- Fixes breaking changes from spec drift: branch endpoint paths, `organization_slug`/`ref` on projects
- Adds CI check to catch future spec drift on PRs
- Fixes coveralls CI: adds missing checkout step (same fix as [supabase/supabase#43285](https://github.com/supabase/supabase/pull/43285)) and aligns coverage output path with supabase monorepo defaults

Tested connecting and running `list_organizations` with the preview build below.

Closes AI-467