### PR TITLE
chore: restrict local paths edge_functions

### DIFF
--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -1545,6 +1545,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{ref}/database/openapi": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get PostgREST OpenAPI spec
+         * @description Returns the PostgREST OpenAPI specification for the project. This is the replacement for querying `/rest/v1/` directly with the anon key.
+         */
+        get: operations["v1-get-database-openapi"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/projects/{ref}/functions": {
         parameters: {
             query?: never;
@@ -4310,6 +4330,8 @@ export interface components {
             name: string;
             /** @enum {string} */
             status: "AVAILABLE" | "PENDING" | "REMOVED" | "FAILED";
+            /** Format: date-time */
+            completed_on: string | null;
         };
         V1UndoBody: {
             name: string;
@@ -9941,6 +9963,59 @@ export interface operations {
                 content?: never;
             };
             /** @description Failed to remove JIT access */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-database-openapi": {
+        parameters: {
+            query?: {
+                /** @description The database schema to generate the OpenAPI spec for */
+                schema?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to fetch PostgREST OpenAPI spec */
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -84,7 +84,14 @@ const listMigrationsOutputSchema = z.object({
 
 const applyMigrationInputSchema = z.object({
   project_id: z.string(),
-  name: z.string().describe('The name of the migration in snake_case'),
+  name: z
+    .string()
+    .describe('The name of the migration in snake_case')
+    .refine(
+      (name) =>
+        !name.includes('/') && !name.includes('\\') && !name.includes('..'),
+      { message: 'Name cannot contain path separators or traversal' }
+    ),
   query: z.string().describe('The SQL query to apply'),
 });
 

--- a/packages/mcp-server-supabase/src/tools/edge-function-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/edge-function-tools.ts
@@ -6,6 +6,7 @@ import {
   edgeFunctionWithBodySchema,
 } from '../platform/types.js';
 import { injectableTool, type ToolDefs } from './util.js';
+import path from 'path';
 
 type EdgeFunctionToolsOptions = {
   functions: EdgeFunctionsOperations;
@@ -48,7 +49,17 @@ const deployEdgeFunctionInputSchema = z.object({
   files: z
     .array(
       z.object({
-        name: z.string(),
+        name: z.string().refine(
+          (filePath) => {
+            const resolved = path.resolve(process.cwd(), filePath);
+            const normalized = path.normalize(resolved);
+            const cwd = process.cwd();
+            return normalized.startsWith(cwd + path.sep) || normalized === cwd;
+          },
+          {
+            message: 'Name must be a path inside the current working directory',
+          }
+        ),
         content: z.string(),
       })
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore

## What is the current behavior?

mcp server has  lax  local path name acceptance

## What is the new behavior?

enforces paths to be in the current working directory


