### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ If you're running Supabase locally with [Supabase CLI](https://supabase.com/docs
 
 For [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting/docker), check the [Enabling MCP server](https://supabase.com/docs/guides/self-hosting/enable-mcp) page. Currently, the MCP Server in self-hosted environments offers a limited subset of tools and no OAuth 2.1.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/supabase-community-supabase-mcp).
+
 ## Options
 
 The following options are configurable as URL query parameters:

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ If you're running Supabase locally with [Supabase CLI](https://supabase.com/docs
 
 For [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting/docker), check the [Enabling MCP server](https://supabase.com/docs/guides/self-hosting/enable-mcp) page. Currently, the MCP Server in self-hosted environments offers a limited subset of tools and no OAuth 2.1.
 
-## Hosted deployment
-
-A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/supabase-community-supabase-mcp).
+A 1-click hosted deployment is also available on [Fronteir AI](https://fronteir.ai/mcp/supabase-community-supabase-mcp).
 
 ## Options
 


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/supabase-community-supabase-mcp).