### PR TITLE
Add recommended security policies for tool-level enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,45 @@ We recommend the following best practices to mitigate security risks when using 
 
 - **Feature groups**: The server allows you to enable or disable specific [tool groups](#feature-groups), so you can control which tools are available to the LLM. This helps reduce the attack surface and limits the actions that LLMs can perform to only those that you need.
 
+### Tool-level policy enforcement (optional)
+
+The above recommendations control **which tools** are available and whether queries are read-only. For tool-level enforcement — rate limiting, daily caps, blocking destructive SQL patterns, and audit logging — you can wrap the server with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy.
+
+Three policy presets are included in [`/policies`](/policies):
+
+| Policy | Description |
+|--------|-------------|
+| `recommended.yaml` | Rate limits on writes, blocks destructive SQL (`DROP`, `TRUNCATE`), caps on migrations and deployments |
+| `strict.yaml` | Default deny — only read tools and `SELECT` queries allowed unless explicitly opted in |
+| `permissive.yaml` | Everything allowed, rate limits on destructive and high-risk operations |
+
+Usage (stdio transport):
+
+```sh
+npx -y @policylayer/intercept \
+  --policy policies/recommended.yaml \
+  -- npx -y @supabase/mcp-server-supabase
+```
+
+Or in your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y", "@policylayer/intercept",
+        "--policy", "policies/recommended.yaml",
+        "--", "npx", "-y", "@supabase/mcp-server-supabase"
+      ]
+    }
+  }
+}
+```
+
+Policies are YAML files you can customise. See the [Intercept docs](https://github.com/policylayer/intercept) for the full reference.
+
 ## Usage with AI SDK's MCP Client
 
 The `@supabase/mcp-server-supabase` package exports `createToolSchemas()` to populate input and output schemas for Vercel AI SDK's [MCP client](https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools). This allows Supabase MCP tools to be treated as static tools with client-side validation and inferred TypeScript types for their inputs and outputs.

--- a/policies/permissive.yaml
+++ b/policies/permissive.yaml
@@ -1,0 +1,64 @@
+version: "1"
+description: "Supabase MCP — permissive policy. All tools allowed. Rate limits on destructive and high-risk operations."
+default: allow
+
+tools:
+  # SQL execution — rate limited even in permissive mode
+  execute_sql:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "30/minute"
+        on_deny: "Max 30 SQL executions per minute"
+
+  # Schema migrations
+  apply_migration:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 migrations per hour"
+
+  # Edge Function deployment
+  deploy_edge_function:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 deployments per hour"
+
+  # Project management
+  create_project:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 project creations per hour"
+
+  pause_project:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 project pauses per hour"
+
+  # Branch management — destructive operations
+  delete_branch:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 branch deletions per hour"
+
+  reset_branch:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 branch resets per hour"
+
+  merge_branch:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "10/hour"
+        on_deny: "Max 10 branch merges per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "120/minute"
+        on_deny: "Global rate limit — max 120 tool calls per minute"

--- a/policies/recommended.yaml
+++ b/policies/recommended.yaml
@@ -1,0 +1,109 @@
+version: "1"
+description: "Supabase MCP — recommended policy. Rate limits on writes, blocks destructive SQL patterns, reads allowed freely."
+default: allow
+
+tools:
+  # SQL execution — highest risk, tightest limits
+  execute_sql:
+    rules:
+      - name: "block-drop"
+        when:
+          args.query: "(?i)\\bDROP\\s+(TABLE|SCHEMA|DATABASE|INDEX|VIEW|FUNCTION|TRIGGER|EXTENSION)\\b"
+        action: deny
+        on_deny: "DROP statements are blocked — use apply_migration for schema changes"
+      - name: "block-truncate"
+        when:
+          args.query: "(?i)\\bTRUNCATE\\b"
+        action: deny
+        on_deny: "TRUNCATE is blocked — use targeted DELETE with WHERE clause instead"
+      - name: "block-delete-without-where"
+        when:
+          args.query: "(?i)\\bDELETE\\s+FROM\\s+\\w+\\s*;?$"
+        action: deny
+        on_deny: "DELETE without WHERE clause is blocked — add a WHERE condition"
+      - name: "block-alter-drop-column"
+        when:
+          args.query: "(?i)\\bALTER\\s+TABLE\\s+.*\\bDROP\\s+COLUMN\\b"
+        action: deny
+        on_deny: "DROP COLUMN is blocked — use apply_migration for schema changes"
+      - name: "burst-limit"
+        rate_limit: "10/minute"
+        on_deny: "Slow down — max 10 SQL executions per minute"
+      - name: "hourly-cap"
+        rate_limit: "120/hour"
+        on_deny: "Hourly SQL execution limit (120) reached"
+
+  # Schema migrations — deliberate changes only
+  apply_migration:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 migrations per minute"
+      - name: "daily-cap"
+        rate_limit: "20/day"
+        on_deny: "Daily migration limit (20) reached"
+
+  # Edge Function deployment — deploys executable code
+  deploy_edge_function:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "3/minute"
+        on_deny: "Slow down — max 3 deployments per minute"
+      - name: "hourly-cap"
+        rate_limit: "10/hour"
+        on_deny: "Hourly deployment limit (10) reached"
+
+  # Project management — high impact
+  create_project:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "3/hour"
+        on_deny: "Max 3 project creations per hour"
+
+  pause_project:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "3/hour"
+        on_deny: "Max 3 project pauses per hour"
+
+  # Branch management — destructive operations
+  delete_branch:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 branch deletions per minute"
+      - name: "daily-cap"
+        rate_limit: "10/day"
+        on_deny: "Daily branch deletion limit (10) reached"
+
+  reset_branch:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 branch resets per minute"
+      - name: "daily-cap"
+        rate_limit: "10/day"
+        on_deny: "Daily branch reset limit (10) reached"
+
+  merge_branch:
+    rules:
+      - name: "burst-limit"
+        rate_limit: "2/minute"
+        on_deny: "Slow down — max 2 branch merges per minute"
+      - name: "daily-cap"
+        rate_limit: "10/day"
+        on_deny: "Daily branch merge limit (10) reached"
+
+  # Storage config — can affect file access
+  update_storage_config:
+    rules:
+      - name: "rate-limit"
+        rate_limit: "5/hour"
+        on_deny: "Max 5 storage config updates per hour"
+
+  # Global safety net
+  "*":
+    rules:
+      - name: "global-rate-limit"
+        rate_limit: "60/minute"
+        on_deny: "Global rate limit — max 60 tool calls per minute across all Supabase tools"

--- a/policies/strict.yaml
+++ b/policies/strict.yaml
@@ -1,0 +1,136 @@
+version: "1"
+description: "Supabase MCP — strict policy. Default deny. Only read and query tools are accessible."
+default: deny
+
+tools:
+  # Account — read-only
+  list_projects:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_project:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_organizations:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_organization:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_cost:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  confirm_cost:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  # Database — read-only queries only
+  list_tables:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_extensions:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  list_migrations:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  execute_sql:
+    rules:
+      - name: "allow-select-only"
+        when:
+          args.query: "(?i)^\\s*SELECT\\b"
+        action: allow
+        rate_limit: "30/minute"
+      - name: "allow-explain"
+        when:
+          args.query: "(?i)^\\s*EXPLAIN\\b"
+        action: allow
+        rate_limit: "30/minute"
+      - name: "allow-show"
+        when:
+          args.query: "(?i)^\\s*SHOW\\b"
+        action: allow
+        rate_limit: "30/minute"
+      - name: "block-all-other-sql"
+        action: deny
+        on_deny: "Only SELECT, EXPLAIN, and SHOW queries are allowed in strict mode"
+
+  # Debugging — read-only
+  get_logs:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_advisors:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  # Development — read-only
+  get_project_url:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_publishable_keys:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  generate_typescript_types:
+    rules:
+      - action: allow
+        rate_limit: "10/minute"
+
+  # Knowledge base
+  search_docs:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  # Edge Functions — read-only
+  list_edge_functions:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_edge_function:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  # Branching — read-only
+  list_branches:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  # Storage — read-only
+  list_storage_buckets:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  get_storage_config:
+    rules:
+      - action: allow
+        rate_limit: "30/minute"
+
+  # Everything else blocked by default: deny
+  # To allow writes, copy rules from recommended.yaml


### PR DESCRIPTION
## Summary

Adds three YAML policy files for use with [PolicyLayer Intercept](https://github.com/policylayer/intercept), an open-source MCP proxy that enforces rate limits, daily caps, and access control on individual tool calls.

The Supabase MCP server exposes `execute_sql` (arbitrary SQL including DDL/DML), `apply_migration` (schema changes), `deploy_edge_function` (executable code deployment), and destructive branch operations. The existing [security recommendations](#recommendations) cover read-only mode, project scoping, and feature groups — these policies add a complementary layer: deterministic, per-tool enforcement that controls **how aggressively** tools are used once access is granted.

## What's included

```
policies/
├── recommended.yaml   # Blocks destructive SQL, rate limits writes, reads allowed freely
├── strict.yaml        # Default deny — only read tools and SELECT queries allowed
└── permissive.yaml    # Everything allowed, rate limits on destructive operations
```

**recommended.yaml** highlights:
- `execute_sql`: blocks `DROP TABLE/SCHEMA/...`, `TRUNCATE`, `DELETE` without `WHERE`, and `DROP COLUMN` — 10/min burst, 120/hour cap
- `apply_migration`: 3/min burst, 20/day cap
- `deploy_edge_function`: 3/min burst, 10/hour cap
- `delete_branch` / `reset_branch` / `merge_branch`: 2/min burst, 10/day cap
- `create_project` / `pause_project`: 3/hour
- Global safety net: 60/min across all tools

**strict.yaml** — read-only mode with teeth:
- Default deny, only read/list/get tools allowed
- `execute_sql` permits only `SELECT`, `EXPLAIN`, and `SHOW` queries — all other SQL blocked
- Complements Supabase's built-in `read_only` mode with explicit per-tool allowlisting

**permissive.yaml** — for development:
- Everything allowed
- Rate limits only on SQL execution, migrations, deployments, and branch operations

## Usage

Wrap the MCP server with Intercept (one line):

```sh
npx -y @policylayer/intercept \
  --policy policies/recommended.yaml \
  -- npx -y @supabase/mcp-server-supabase
```

Or in MCP client config:

```json
{
  "mcpServers": {
    "supabase": {
      "command": "npx",
      "args": [
        "-y", "@policylayer/intercept",
        "--policy", "policies/recommended.yaml",
        "--", "npx", "-y", "@supabase/mcp-server-supabase"
      ]
    }
  }
}
```

Also added a README section under "Tool-level policy enforcement" within the Security risks section.

## Why this matters

Supabase MCP is uniquely powerful because `execute_sql` accepts arbitrary SQL — an agent can `DROP TABLE`, `TRUNCATE`, or run destructive `DELETE` statements with no guardrails beyond manual approval clicks. Read-only mode is an all-or-nothing switch. These policies add graduated enforcement: block the most dangerous patterns, rate limit writes, and cap deployments — without removing write access entirely.

## About PolicyLayer Intercept

- Open source (MIT): [github.com/policylayer/intercept](https://github.com/policylayer/intercept)
- npm: `@policylayer/intercept`
- Sub-millisecond evaluation, fail-closed, deterministic (not prompt-based)
- Supports all MCP clients: Claude Desktop, Claude Code, Cursor, VS Code, Windsurf, etc.
- Zero changes to the MCP server — wraps the command transparently
- Structured JSON audit logs for every tool call decision