### PR TITLE
fix: move @modelcontextprotocol/sdk to dependencies to prevent npx crash

### DIFF
--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -28,7 +28,9 @@
     "test:coverage": "vitest --coverage",
     "generate:management-api-types": "openapi-typescript https://api.supabase.com/api/v1-json -o ./src/management-api/types.ts"
   },
-  "files": ["dist/**/*"],
+  "files": [
+    "dist/**/*"
+  ],
   "bin": {
     "mcp-server-supabase": "./dist/transports/stdio.js"
   },
@@ -50,6 +52,7 @@
     }
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@mjackson/multipart-parser": "^0.10.1",
     "@supabase/mcp-utils": "workspace:^",
     "common-tags": "^1.8.2",
@@ -58,14 +61,12 @@
     "openapi-fetch": "^0.13.5"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "catalog:",
     "@ai-sdk/mcp": "catalog:",
     "@electric-sql/pglite": "^0.2.17",
-    "@modelcontextprotocol/sdk": "catalog:",
     "@total-typescript/tsconfig": "^1.0.4",
     "@types/common-tags": "^1.8.4",
     "@types/node": "^22.8.6",


### PR DESCRIPTION
Fixes supabase/supabase#44758

Description
Currently, users running npx -y @supabase/mcp-server-supabase@latest on a fresh environment experience an immediate crash: ERR_MODULE_NOT_FOUND: Cannot find package '@modelcontextprotocol/sdk'.

The Root Cause:
@modelcontextprotocol/sdk was listed under both peerDependencies and devDependencies in packages/mcp-server-supabase/package.json. Because npx does not automatically install peer dependencies, and dev dependencies are excluded from production builds, the SDK is completely missing at runtime for standard CLI users.

The Fix:
Since the MCP SDK is an internal implementation detail and strictly required for the server to run over stdio, I moved it to a hard dependency. (I left zod as a peer dependency since it is a common shared library).

This ensures the SDK is bundled correctly when users execute the tool via npx.