### PR TITLE
feat: server instructions

### DIFF
--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -142,8 +142,6 @@ export interface paths {
         /**
          * List all projects
          * @description Returns a list of all projects you've previously created.
-         *
-         *     Use `/v1/organizations/{slug}/projects` instead when possible to get more precise results and pagination support.
          */
         get: operations["v1-list-all-projects"];
         put?: never;
@@ -2146,34 +2144,6 @@ export interface components {
         BranchRestoreResponse: {
             /** @enum {string} */
             message: "Branch restoration initiated";
-        };
-        V1ListProjectsPaginatedResponse: {
-            projects: {
-                id: number;
-                cloud_provider: string;
-                inserted_at: string | null;
-                name: string;
-                organization_id: number;
-                organization_slug: string;
-                ref: string;
-                region: string;
-                status: string;
-                subscription_id: string | null;
-                is_branch_enabled: boolean;
-                is_physical_backups_enabled: boolean | null;
-                preview_branch_refs: string[];
-                disk_volume_size_gb?: number;
-                /** @enum {string} */
-                infra_compute_size?: "pico" | "nano" | "micro" | "small" | "medium" | "large" | "xlarge" | "2xlarge" | "4xlarge" | "8xlarge" | "12xlarge" | "16xlarge" | "24xlarge" | "24xlarge_optimized_memory" | "24xlarge_optimized_cpu" | "24xlarge_high_memory" | "48xlarge" | "48xlarge_optimized_memory" | "48xlarge_optimized_cpu" | "48xlarge_high_memory";
-            }[];
-            pagination: {
-                /** @description Total number of projects. Use this to calculate the total number of pages. */
-                count: number;
-                /** @description Maximum number of projects per page (actual number may be less) */
-                limit: number;
-                /** @description Number of projects skipped in this response */
-                offset: number;
-            };
         };
         V1ProjectWithDatabaseResponse: {
             /**

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -28,7 +28,7 @@ import {
 import { createSupabaseApiPlatform } from './platform/api-platform.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { BRANCH_COST_HOURLY, PROJECT_COST_MONTHLY } from './pricing.js';
-import { createSupabaseMcpServer } from './server.js';
+import { createSupabaseMcpServer, instructions } from './server.js';
 import {
   createToolSchemas,
   supabaseMcpToolSchemas,
@@ -129,6 +129,13 @@ async function setup(options: SetupOptions = {}) {
 
   return { client, clientTransport, callTool, server, serverTransport };
 }
+
+describe('init', () => {
+  test('server returns instructions', async () => {
+    const { client } = await setup();
+    expect(client.getInstructions()).toBe(instructions);
+  });
+});
 
 describe('tools', () => {
   test('list organizations', async () => {

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -73,7 +73,6 @@ Here are guidelines for using Supabase tools effectively:
 - Before making schema changes, use \`list_tables\` to understand the existing structure
 - When debugging issues, start with \`get_logs\` and \`get_advisors\` before making changes
 - Use \`get_project_url\` and \`get_publishable_api_key\` when helping users configure client-side integrations
-- For cost-incurring operations (e.g. creating projects or branches), always call \`confirm_cost\` first
 
 If you have access to a local development environment with a filesystem and shell:
 - Install the Supabase agent skill for critical development and security guidance: \`npx skills add supabase/agent-skills\` (https://supabase.com/docs/guides/getting-started/ai-skills.md)

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -67,6 +67,24 @@ const DEFAULT_FEATURES: FeatureGroup[] = [
 
 export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];
 
+const instructions = `
+Here are guidelines for using Supabase tools effectively:
+
+- Before making schema changes, use \`list_tables\` to understand the existing structure
+- When debugging issues, start with \`get_logs\` and \`get_advisors\` before making changes
+- Use \`get_project_url\` and \`get_publishable_api_key\` when helping users configure client-side integrations
+- For cost-incurring operations (e.g. creating projects or branches), always call \`confirm_cost\` first
+
+If you have access to a local development environment with a filesystem and shell:
+- Install the Supabase agent skill for critical development and security guidance: \`npx skills add supabase/agent-skills\` (https://supabase.com/docs/guides/getting-started/ai-skills.md)
+- Use the Supabase CLI (\`supabase\`) for local development workflows such as starting a local stack, managing migrations, and running edge functions locally (https://supabase.com/docs/guides/local-development.md)
+- Prefer local development and testing before applying changes to a remote project
+
+If you are running in a web-only or remote environment without filesystem or shell access:
+- Rely on the MCP tools directly for all Supabase interactions
+- Use \`apply_migration\` carefully, as changes go directly to the remote project
+`.trim();
+
 /**
  * Creates an MCP server for interacting with Supabase.
  */
@@ -101,6 +119,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     name: 'supabase',
     title: 'Supabase',
     version,
+    instructions,
     async onInitialize(info) {
       // Note: in stateless HTTP mode, `onInitialize` will not always be called
       // so we cannot rely on it for initialization. It's still useful for telemetry.

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -67,7 +67,7 @@ const DEFAULT_FEATURES: FeatureGroup[] = [
 
 export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];
 
-const instructions = `
+export const instructions = `
 Here are guidelines for using Supabase tools effectively:
 
 - Before making schema changes, use \`list_tables\` to understand the existing structure

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -229,6 +229,15 @@ export type McpServerOptions = {
   onInitialize?: InitCallback;
 
   /**
+   * Optional instructions describing how to use the server and its features.
+   *
+   * This can be used by clients to improve the LLM's understanding of available
+   * tools, resources, etc. It can be thought of like a "hint" to the model.
+   * For example, this information MAY be added to the system prompt.
+   */
+  instructions?: string;
+
+  /**
    * Callback for after a tool is called.
    */
   onToolCall?: ToolCallCallback;
@@ -283,6 +292,7 @@ export function createMcpServer(options: McpServerOptions) {
     },
     {
       capabilities,
+      instructions: options.instructions,
     }
   );
 


### PR DESCRIPTION
The MCP spec supports [instructions](https://modelcontextprotocol.io/specification/draft/schema#initializeresult) from the server that MCP clients pass to the LLM as extra context (e.g. via system prompt). This PR adds these instructions for Supabase MCP.

Closes AI-670