### PR TITLE
feat: extra validation to platform schemas

### DIFF
--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -2630,21 +2630,15 @@ export interface components {
         UpdateCustomHostnameBody: {
             custom_hostname: string;
         };
-        JitAccessResponse: {
-            /** Format: uuid */
-            user_id: string;
-            user_roles: {
-                role: string;
-                expires_at?: number;
-                allowed_networks?: {
-                    allowed_cidrs?: {
-                        cidr: string;
-                    }[];
-                    allowed_cidrs_v6?: {
-                        cidr: string;
-                    }[];
-                };
-            }[];
+        JitStateResponse: {
+            /** @enum {string} */
+            state: "enabled" | "disabled";
+            appliedSuccessfully?: boolean;
+        } | {
+            /** @enum {string} */
+            state: "unavailable";
+            /** @enum {string} */
+            unavailableReason: "manual_migration_required" | "postgres_upgrade_required" | "temporarily_unavailable";
         };
         /** @example {
          *       "state": "enabled"
@@ -3893,6 +3887,22 @@ export interface components {
         V1UpdatePasswordResponse: {
             message: string;
         };
+        JitAccessResponse: {
+            /** Format: uuid */
+            user_id: string;
+            user_roles: {
+                role: string;
+                expires_at?: number;
+                allowed_networks?: {
+                    allowed_cidrs?: {
+                        cidr: string;
+                    }[];
+                    allowed_cidrs_v6?: {
+                        cidr: string;
+                    }[];
+                };
+            }[];
+        };
         /** @example {
          *       "role": "postgres",
          *       "rhost": "203.0.113.10"
@@ -5045,6 +5055,27 @@ export interface operations {
                     "application/json": components["schemas"]["V1ProjectWithDatabaseResponse"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     "v1-create-a-project": {
@@ -5067,6 +5098,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["V1ProjectResponse"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -5113,6 +5165,27 @@ export interface operations {
                     "application/json": components["schemas"]["OrganizationResponseV1"][];
                 };
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Unexpected error listing organizations */
             500: {
                 headers: {
@@ -5142,6 +5215,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["OrganizationResponseV1"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Unexpected error creating an organization */
             500: {
@@ -5251,6 +5345,27 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     "v1-list-all-snippets": {
@@ -5276,6 +5391,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SnippetList"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Failed to list user's SQL snippets */
             500: {
@@ -5304,6 +5440,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SnippetResponse"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Failed to retrieve SQL snippet */
             500: {
@@ -5949,27 +6106,6 @@ export interface operations {
                     "application/json": components["schemas"]["BranchResponse"][];
                 };
             };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Forbidden action */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Rate limit exceeded */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
             /** @description Failed to retrieve database branches */
             500: {
                 headers: {
@@ -6002,27 +6138,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["BranchResponse"];
                 };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Forbidden action */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Rate limit exceeded */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
             /** @description Failed to create database branch */
             500: {
@@ -6101,27 +6216,6 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["BranchResponse"];
                 };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Forbidden action */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Rate limit exceeded */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
             /** @description Failed to fetch database branch */
             500: {
@@ -6401,7 +6495,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["JitAccessResponse"];
+                    "application/json": components["schemas"]["JitStateResponse"];
                 };
             };
             /** @description Unauthorized */
@@ -6455,7 +6549,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["JitAccessResponse"];
+                    "application/json": components["schemas"]["JitStateResponse"];
                 };
             };
             /** @description Unauthorized */
@@ -12332,6 +12426,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["OrganizationProjectsResponse"];
                 };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Failed to retrieve projects */
             500: {

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -16,7 +16,7 @@ export const storageBucketSchema = z.object({
 });
 
 export const storageConfigSchema = z.object({
-  fileSizeLimit: z.number(),
+  fileSizeLimit: z.number().int().min(0).max(536_870_912_000), // 500GB
   features: z.object({
     imageTransformation: z.object({ enabled: z.boolean() }),
     s3Protocol: z.object({ enabled: z.boolean() }),
@@ -88,14 +88,14 @@ export const edgeFunctionWithBodySchema = edgeFunctionSchema.extend({
 });
 
 export const createProjectOptionsSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1).max(256),
   organization_id: z.string(),
   region: z.enum(AWS_REGION_CODES),
   db_pass: z.string().optional(),
 });
 
 export const createBranchOptionsSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1),
 });
 
 export const resetBranchOptionsSchema = z.object({
@@ -103,7 +103,7 @@ export const resetBranchOptionsSchema = z.object({
 });
 
 export const deployEdgeFunctionOptionsSchema = z.object({
-  name: z.string(),
+  name: z.string().regex(/^[A-Za-z][A-Za-z0-9_-]*$/),
   entrypoint_path: z.string(),
   import_map_path: z.string().optional(),
   verify_jwt: z.boolean().optional(),
@@ -116,14 +116,14 @@ export const deployEdgeFunctionOptionsSchema = z.object({
 });
 
 export const executeSqlOptionsSchema = z.object({
-  query: z.string(),
+  query: z.string().min(1),
   parameters: z.array(z.unknown()).optional(),
   read_only: z.boolean().optional(),
 });
 
 export const applyMigrationOptionsSchema = z.object({
-  name: z.string(),
-  query: z.string(),
+  name: z.string().min(1),
+  query: z.string().min(1),
 });
 
 export const migrationSchema = z.object({


### PR DESCRIPTION
Tightens Zod schemas in `platform/types.ts` to cover name lengths, non-empty strings, edge function slug format, and file size limits. The intent of these schemas is to provide "convenience DTOs" that downstream platform implementations can use to perform their own validation (it makes validation more explicit / less opaque for downstream platform implementations).

One nuance here is that we already have separate input validation at the tool level. So in a way, the validation is duplicated between those schemas and these schemas. But then again, the platform abstraction has a slightly different interface than tools, so validating these separately might be justified. Happy to discuss the best solution here. To me it's a trade-off between duplicate logic, correctness, and transparency.