### PR TITLE
chore: fix release-please setup follow-ups

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/mcp-utils": "0.7.0",
+  "packages/mcp-utils": "0.4.0",
   "packages/mcp-server-supabase": "0.7.0",
   "packages/mcp-server-postgrest": "0.7.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/mcp-utils": "0.4.0",
   "packages/mcp-server-supabase": "0.7.0",
-  "packages/mcp-server-postgrest": "0.7.0"
+  "packages/mcp-server-postgrest": "0.1.0"
 }

--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,9 @@
     "ignoreUnknown": false,
     "ignore": [
       "**/dist",
+      "**/CHANGELOG.md",
+      ".release-please-manifest.json",
+      "**/package.json",
       "packages/mcp-server-supabase/src/management-api/types.ts"
     ]
   },

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,6 @@
     "ignoreUnknown": false,
     "ignore": [
       "**/dist",
-      "**/CHANGELOG.md",
       ".release-please-manifest.json",
       "**/package.json",
       "packages/mcp-server-supabase/src/management-api/types.ts"

--- a/packages/mcp-server-postgrest/package.json
+++ b/packages/mcp-server-postgrest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/mcp-server-postgrest",
-  "version": "0.7.0",
+  "version": "0.1.0",
   "description": "MCP server for PostgREST",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supabase/mcp-utils",
-  "version": "0.7.0",
+  "version": "0.4.0",
   "description": "MCP utilities",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Follow-up fixes to #262 based on findings from the first automatic Release Please PR https://github.com/supabase-community/supabase-mcp/pull/265

- Reset `mcp-utils` and `mcp-server-postgrest` manifest versions to their last published npm versions (`0.4.0` and `0.1.0` respectively), they were accidentally manually bumped to `0.7.0` as part of the original version syncing approach on prev PR
- Exclude `.release-please-manifest.json` and `package.json` from Biome to avoid format conflicts with release-please's JSON serializer

(Marking this as `chore:` so Release Please ignores it in changelog)