### PR TITLE
fix: tools not loading on stdio server

### DIFF
--- a/packages/mcp-server-supabase/src/content-api/graphql.ts
+++ b/packages/mcp-server-supabase/src/content-api/graphql.ts
@@ -13,11 +13,6 @@ export const graphqlRequestSchema = z.object({
   variables: z.record(z.string(), z.unknown()).optional(),
 });
 
-export const graphqlResponseSuccessSchema = z.object({
-  data: z.record(z.string(), z.unknown()),
-  errors: z.undefined(),
-});
-
 export const graphqlErrorSchema = z.object({
   message: z.string(),
   locations: z.array(
@@ -28,15 +23,10 @@ export const graphqlErrorSchema = z.object({
   ),
 });
 
-export const graphqlResponseErrorSchema = z.object({
-  data: z.undefined(),
-  errors: z.array(graphqlErrorSchema),
+export const graphqlResponseSchema = z.object({
+  data: z.record(z.string(), z.unknown()).nullish(),
+  errors: z.array(graphqlErrorSchema).optional(),
 });
-
-export const graphqlResponseSchema = z.union([
-  graphqlResponseSuccessSchema,
-  graphqlResponseErrorSchema,
-]);
 
 export type GraphQLRequest = z.infer<typeof graphqlRequestSchema>;
 export type GraphQLResponse = z.infer<typeof graphqlResponseSchema>;
@@ -195,7 +185,7 @@ export class GraphQLClient {
       );
     }
 
-    if (data.errors) {
+    if (data.errors?.length) {
       throw new Error(
         `Supabase Content API GraphQL error: ${data.errors
           .map(
@@ -204,6 +194,10 @@ export class GraphQLClient {
           )
           .join(', ')}`
       );
+    }
+
+    if (!data.data) {
+      throw new Error('Supabase Content API returned no data');
     }
 
     return data.data;


### PR DESCRIPTION
## Problem
The docs Content API GraphQL response schema (used for the `search_docs` tool) used a discriminated union with `z.undefined()` to model success/error branches. There were 2 issues:

1. Zod v4 had a breaking change where `z.undefined()` on object properties requires the key to be explicitly present (and set as `undefined`). Absent keys failed validation, which broke tool loading
2. The union was actually incorrect from the beginning. The GraphQL spec allows both `data` and `errors` at the same time (partial results)

## Fix

This PR replaces the union with a flat schema. `data` uses `.nullish()` because the spec allows it to be either absent (validation errors before execution) or `null` (resolver errors on non-nullable fields). `errors` uses `.optional()` since it's simply absent on success.

## How to test

Configure Claude Code with the following MCP server config:

```json
{
  "mcpServers": {
    "supabase-stdio": {
      "command": "npx",
      "args": [
        "-y",
        "@supabase/mcp-server-supabase@https://pkg.pr.new/supabase-community/supabase-mcp/@supabase/mcp-server-supabase@bbbe8ba"
      ],
      "env": {
        "SUPABASE_ACCESS_TOKEN": "<pat>"
      }
    }
  }
}
```

Run the `claude` CLI, enter `/mcp`, select `supabase-stdio`.
1. Confirm that the server connected successfully
2. Confirm that tools are available (by the presence of the **View tools** option, which displays all the tools when selected)

---

Resolves #261