### PR TITLE
chore(test): add 'invalid slug' function deploy test

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1731,6 +1731,42 @@ describe('tools', () => {
     );
   });
 
+  test('deploy edge function with invalid slug throws an error', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'test-org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'test-app',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const functionSlug = '[DEPRECATED] hello-world';
+    const functionCode = 'console.log("Hello, world!");';
+
+    const result = callTool({
+      name: 'deploy_edge_function',
+      arguments: {
+        project_id: project.id,
+        name: functionSlug,
+        files: [
+          {
+            name: 'index.ts',
+            content: functionCode,
+          },
+        ],
+      },
+    });
+
+    await expect(result).rejects.toThrow('Invalid string: must match pattern');
+  });
+
   test('deploy new version of existing edge function', async () => {
     const { callTool } = await setup();
     const org = await createOrganization({

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1731,7 +1731,7 @@ describe('tools', () => {
     );
   });
 
-  test('deploy edge function with invalid slug throws an error', async () => {
+  test('eploy edge function validates slug format', async () => {
     const { callTool } = await setup();
 
     const org = await createOrganization({
@@ -1747,14 +1747,51 @@ describe('tools', () => {
     });
     project.status = 'ACTIVE_HEALTHY';
 
-    const functionSlug = '[DEPRECATED] hello-world';
+    const functionInvalidSlugs = [
+      // Leading character violations
+      '[DEPRECATED] hello-world', // leading bracket
+      '_hello-world',             // leading underscore
+      '-hello-world',             // leading hyphen
+      '0hello-world',             // leading digit
+      '#hello-world',             // leading special char
+      '.hello-world',             // leading dot
+
+      // Trailing character violations
+      'hello-world ',             // trailing space
+      'hello-world.',             // trailing dot
+      'hello-world#',             // trailing hash
+      'hello-world!',             // trailing exclamation
+      'hello-world@',             // trailing at sign
+      'hello-world[',             // trailing bracket
+
+      // Whitespace
+      'hello world',              // space
+      'hello\tworld',             // tab
+      'hello\nworld',             // newline
+      ' hello-world',             // leading space
+
+      // Special characters in body
+      'hello.world',              // dot
+      'hello@world',              // at sign
+      'hello/world',              // slash
+      'hello\\world',             // backslash
+      'hello$world',              // dollar sign
+      'hello!world',              // exclamation
+
+      // Edge cases
+      '',                         // empty string
+      ' ',                        // only space
+      '-',                        // only hyphen
+      '_',                        // only underscore
+    ];
+
     const functionCode = 'console.log("Hello, world!");';
 
-    const result = callTool({
+    functionInvalidSlugs.map((slug) => callTool({
       name: 'deploy_edge_function',
       arguments: {
         project_id: project.id,
-        name: functionSlug,
+        name: slug,
         files: [
           {
             name: 'index.ts',
@@ -1762,9 +1799,11 @@ describe('tools', () => {
           },
         ],
       },
-    });
+    }))
+      .forEach(async result => {
+        await expect(result).rejects.toThrow('Invalid string: must match pattern');
+      })
 
-    await expect(result).rejects.toThrow('Invalid string: must match pattern');
   });
 
   test('deploy new version of existing edge function', async () => {
@@ -2340,7 +2379,7 @@ describe('tools', () => {
     );
     expect(listBranchesResultAfterDelete.branches).toHaveLength(1);
 
-    const mainBranch = listBranchesResultAfterDelete.branches[0];
+    const mainBranch = listBranchesResultAfterDelete.branches[-1];
 
     const deleteBranchPromise = callTool({
       name: 'delete_branch',

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1750,60 +1750,64 @@ describe('tools', () => {
     const functionInvalidSlugs = [
       // Leading character violations
       '[DEPRECATED] hello-world', // leading bracket
-      '_hello-world',             // leading underscore
-      '-hello-world',             // leading hyphen
-      '0hello-world',             // leading digit
-      '#hello-world',             // leading special char
-      '.hello-world',             // leading dot
+      '_hello-world', // leading underscore
+      '-hello-world', // leading hyphen
+      '0hello-world', // leading digit
+      '#hello-world', // leading special char
+      '.hello-world', // leading dot
 
       // Trailing character violations
-      'hello-world ',             // trailing space
-      'hello-world.',             // trailing dot
-      'hello-world#',             // trailing hash
-      'hello-world!',             // trailing exclamation
-      'hello-world@',             // trailing at sign
-      'hello-world[',             // trailing bracket
+      'hello-world ', // trailing space
+      'hello-world.', // trailing dot
+      'hello-world#', // trailing hash
+      'hello-world!', // trailing exclamation
+      'hello-world@', // trailing at sign
+      'hello-world[', // trailing bracket
 
       // Whitespace
-      'hello world',              // space
-      'hello\tworld',             // tab
-      'hello\nworld',             // newline
-      ' hello-world',             // leading space
+      'hello world', // space
+      'hello\tworld', // tab
+      'hello\nworld', // newline
+      ' hello-world', // leading space
 
       // Special characters in body
-      'hello.world',              // dot
-      'hello@world',              // at sign
-      'hello/world',              // slash
-      'hello\\world',             // backslash
-      'hello$world',              // dollar sign
-      'hello!world',              // exclamation
+      'hello.world', // dot
+      'hello@world', // at sign
+      'hello/world', // slash
+      'hello\\world', // backslash
+      'hello$world', // dollar sign
+      'hello!world', // exclamation
 
       // Edge cases
-      '',                         // empty string
-      ' ',                        // only space
-      '-',                        // only hyphen
-      '_',                        // only underscore
+      '', // empty string
+      ' ', // only space
+      '-', // only hyphen
+      '_', // only underscore
     ];
 
     const functionCode = 'console.log("Hello, world!");';
 
-    functionInvalidSlugs.map((slug) => callTool({
-      name: 'deploy_edge_function',
-      arguments: {
-        project_id: project.id,
-        name: slug,
-        files: [
-          {
-            name: 'index.ts',
-            content: functionCode,
+    functionInvalidSlugs
+      .map((slug) =>
+        callTool({
+          name: 'deploy_edge_function',
+          arguments: {
+            project_id: project.id,
+            name: slug,
+            files: [
+              {
+                name: 'index.ts',
+                content: functionCode,
+              },
+            ],
           },
-        ],
-      },
-    }))
-      .forEach(async result => {
-        await expect(result).rejects.toThrow('Invalid string: must match pattern');
-      })
-
+        })
+      )
+      .forEach(async (result) => {
+        await expect(result).rejects.toThrow(
+          'Invalid string: must match pattern'
+        );
+      });
   });
 
   test('deploy new version of existing edge function', async () => {


### PR DESCRIPTION
This ensures that invalid functions slug will throw

## What kind of change does this PR introduce?

Feature, test update

## What is the current behavior?

There's no tests to ensure invalid function slugs throw error

## What is the new behavior?

Add unit test for invalid function slugs

-- 

Towards FUNC-580