### PR TITLE
feat: add fetch option to createSupabaseApiPlatform for in-process transports

### DIFF
--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "catalog:",
+    "hono": "^4.7.10",
     "@ai-sdk/mcp": "catalog:",
     "@electric-sql/pglite": "^0.2.17",
     "@modelcontextprotocol/sdk": "catalog:",

--- a/packages/mcp-server-supabase/src/management-api/index.ts
+++ b/packages/mcp-server-supabase/src/management-api/index.ts
@@ -14,7 +14,8 @@ import type { paths } from './types.js';
 export function createManagementApiClient(
   baseUrl: string,
   accessToken: string,
-  headers: Record<string, string> = {}
+  headers: Record<string, string> = {},
+  fetch?: (request: Request) => Response | Promise<Response>
 ) {
   return createClient<paths>({
     baseUrl,
@@ -22,6 +23,7 @@ export function createManagementApiClient(
       Authorization: `Bearer ${accessToken}`,
       ...headers,
     },
+    fetch: fetch ? (request) => Promise.resolve(fetch(request)) : undefined,
   });
 }
 

--- a/packages/mcp-server-supabase/src/platform/api-platform.test.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.test.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono';
+import { describe, expect, test } from 'vitest';
+import { createSupabaseApiPlatform } from './api-platform.js';
+
+describe('createSupabaseApiPlatform with custom fetch', () => {
+  test('routes management API calls through custom fetch handler', async () => {
+    const projects = [
+      {
+        id: 'proj1',
+        ref: 'proj1',
+        name: 'Test Project',
+        organization_id: 'org1',
+        organization_slug: 'org1',
+        status: 'ACTIVE_HEALTHY',
+        created_at: new Date().toISOString(),
+        region: 'us-east-1',
+      },
+    ];
+
+    const app = new Hono().get('/v1/projects', (c) => c.json(projects));
+
+    const platform = createSupabaseApiPlatform({
+      accessToken: 'test-token',
+      fetch: app.fetch.bind(app),
+    });
+
+    // Destructure so TypeScript can narrow the type after the guard below.
+    const { account } = platform;
+    if (!account) {
+      throw new Error('account should be defined on the API platform');
+    }
+
+    const result = await account.listProjects();
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('Test Project');
+  });
+});

--- a/packages/mcp-server-supabase/src/platform/api-platform.test.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.test.ts
@@ -24,13 +24,11 @@ describe('createSupabaseApiPlatform with custom fetch', () => {
       fetch: app.fetch.bind(app),
     });
 
-    // Destructure so TypeScript can narrow the type after the guard below.
-    const { account } = platform;
-    if (!account) {
+    if (!platform.account) {
       throw new Error('account should be defined on the API platform');
     }
 
-    const result = await account.listProjects();
+    const result = await platform.account.listProjects();
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('Test Project');
   });

--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -57,6 +57,12 @@ export type SupabaseApiPlatformOptions = {
    * The API URL for the Supabase Management API.
    */
   apiUrl?: string;
+
+  /**
+   * Custom fetch implementation. Useful for in-process transports (e.g. a
+   * Hono app's `app.fetch`) so callers can avoid binding a real TCP port.
+   */
+  fetch?: (request: Request) => Response | Promise<Response>;
 };
 
 /**
@@ -65,13 +71,15 @@ export type SupabaseApiPlatformOptions = {
 export function createSupabaseApiPlatform(
   options: SupabaseApiPlatformOptions
 ): SupabasePlatform {
-  const { accessToken, apiUrl } = options;
+  const { accessToken, apiUrl, fetch } = options;
 
   const managementApiUrl = apiUrl ?? 'https://api.supabase.com';
 
   let managementApiClient = createManagementApiClient(
     managementApiUrl,
-    accessToken
+    accessToken,
+    {},
+    fetch
   );
 
   const account: AccountOperations = {
@@ -788,7 +796,8 @@ export function createSupabaseApiPlatform(
         accessToken,
         {
           'User-Agent': `supabase-mcp/${version} (${clientInfo.name}/${clientInfo.version})`,
-        }
+        },
+        fetch
       );
     },
     account,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
+      hono:
+        specifier: ^4.7.10
+        version: 4.11.3
       msw:
         specifier: ^2.7.3
         version: 2.10.5(@types/node@22.17.2)(typescript@5.9.2)


### PR DESCRIPTION
Adds a `fetch` option to `SupabaseApiPlatformOptions` and `createManagementApiClient`, allowing callers to pass a custom fetch handler (e.g. `app.fetch.bind(app)` from a Hono app) instead of going through a real TCP connection.

Typed as `(request: Request) => Response | Promise<Response>` to match Hono and other web-standard handlers directly. The `Promise.resolve` coercion to satisfy openapi-fetch's narrower type happens internally at the `createClient` call site.

Closes AI-702