### PR TITLE
fix: restore correct MCP output shape in prompt injection e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .temp/
 .DS_Store
 .env*
+.worktrees/

--- a/packages/mcp-server-supabase/test/e2e/prompt-injection.e2e.ts
+++ b/packages/mcp-server-supabase/test/e2e/prompt-injection.e2e.ts
@@ -100,10 +100,15 @@ describe('prompt injection e2e tests', () => {
       throw new Error('Expected execute_sql call querying tickets');
     }
 
-    // Extract the first row of the result
-    const [ticketsResultRow] = JSON.parse(
-      ticketsResult.output.result.split('\n')[3]
-    );
+    // Extract the first row of the result.
+    // MCP tools return CallToolResult: { content: [{ type: 'text', text: JSON.stringify(toolOutput) }] }
+    const outputText = (
+      ticketsResult.output as { content: Array<{ type: string; text: string }> }
+    ).content[0]?.text;
+    const { result } = JSON.parse(outputText) as { result: string };
+    const [ticketsResultRow] = JSON.parse(result.split('\n')[3]) as Array<{
+      content: string;
+    }>;
 
     // Ensure that the model saw the prompt injection content
     expect(ticketsResultRow.content).toEqual(promptInjectionContent);


### PR DESCRIPTION
## Summary

- Commit `2465610` (typed tool outputs) updated the prompt injection test to access `output.result` directly, anticipating structured tool output on the MCP wire
- That structured output feature was explicitly dropped before the PR merged ("feat: drop outputSchema/structuredContent from MCP wire"), but the test wasn't reverted
- MCP tools still return the standard `CallToolResult` shape: `{ content: [{ type: 'text', text: JSON.stringify(toolOutput) }] }`, so `output.result` is always `undefined` at runtime

## Fix

Restores the correct access pattern: navigate through `output.content[0].text` → JSON parse → `.result` → split lines → parse rows. This is the same logic as the original pre-`2465610` code, just without the `@ts-expect-error` since types are cleaner now.

## Test plan

- [ ] `pnpm --filter @supabase/mcp-server-supabase exec vitest run --project unit` — all unit tests pass
- [ ] `pnpm --filter @supabase/mcp-server-supabase exec vitest run --project e2e -- prompt-injection` — e2e test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)