### PR TITLE
fix: add focused log filters

### DIFF
--- a/packages/mcp-server-supabase/src/logs.test.ts
+++ b/packages/mcp-server-supabase/src/logs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { getLogQuery } from './logs.js';
+
+describe('getLogQuery', () => {
+  test('uses the default limit without a search filter', () => {
+    const query = getLogQuery('edge-function');
+
+    expect(query).toContain('from function_edge_logs');
+    expect(query).not.toContain('where (');
+    expect(query).toContain('limit 100');
+  });
+
+  test('filters edge function logs across message and function metadata', () => {
+    const query = getLogQuery('edge-function', {
+      search: 'billing-worker',
+      limit: 25,
+    });
+
+    expect(query).toContain('where (');
+    expect(query).toContain('event_message');
+    expect(query).toContain('m.function_id');
+    expect(query).toContain("'billing-worker'");
+    expect(query).toContain('limit 25');
+  });
+
+  test('escapes search terms before embedding them in the log query', () => {
+    const query = getLogQuery('auth', {
+      search: "can't sign in",
+      limit: 10,
+    });
+
+    expect(query).toContain("'can''t sign in'");
+    expect(query).toContain('metadata.path');
+    expect(query).toContain('metadata.error');
+  });
+});

--- a/packages/mcp-server-supabase/src/logs.ts
+++ b/packages/mcp-server-supabase/src/logs.ts
@@ -1,7 +1,17 @@
 import { stripIndent } from 'common-tags';
 import type { LogsService } from './platform/types.js';
 
-export function getLogQuery(service: LogsService, limit: number = 100) {
+export type LogQueryOptions = {
+  limit?: number;
+  search?: string;
+};
+
+export function getLogQuery(
+  service: LogsService,
+  { limit = 100, search }: LogQueryOptions = {}
+) {
+  const whereClause = getSearchWhereClause(service, search);
+
   switch (service) {
     case 'api':
       return stripIndent`
@@ -10,12 +20,14 @@ export function getLogQuery(service: LogsService, limit: number = 100) {
         cross join unnest(metadata) as m
         cross join unnest(m.request) as request
         cross join unnest(m.response) as response
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
     case 'branch-action':
       return stripIndent`
         select workflow_run, workflow_run_logs.timestamp, id, event_message from workflow_run_logs
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
@@ -24,6 +36,7 @@ export function getLogQuery(service: LogsService, limit: number = 100) {
         select identifier, postgres_logs.timestamp, id, event_message, parsed.error_severity from postgres_logs
         cross join unnest(metadata) as m
         cross join unnest(m.parsed) as parsed
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
@@ -33,6 +46,7 @@ export function getLogQuery(service: LogsService, limit: number = 100) {
         cross join unnest(metadata) as m
         cross join unnest(m.response) as response
         cross join unnest(m.request) as request
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
@@ -40,22 +54,86 @@ export function getLogQuery(service: LogsService, limit: number = 100) {
       return stripIndent`
         select id, auth_logs.timestamp, event_message, metadata.level, metadata.status, metadata.path, metadata.msg as msg, metadata.error from auth_logs
         cross join unnest(metadata) as metadata
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
     case 'storage':
       return stripIndent`
         select id, storage_logs.timestamp, event_message from storage_logs
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
     case 'realtime':
       return stripIndent`
         select id, realtime_logs.timestamp, event_message from realtime_logs
+        ${whereClause}
         order by timestamp desc
         limit ${limit}
       `;
     default:
       throw new Error(`unsupported log service type: ${service}`);
   }
+}
+
+function getSearchWhereClause(service: LogsService, search?: string) {
+  const searchTerm = search?.trim();
+  if (!searchTerm) return '';
+
+  const literal = sqlStringLiteral(searchTerm.toLowerCase());
+  const fields = getSearchableFields(service);
+  const predicates = fields.map(
+    (field) => `strpos(lower(cast(${field} as string)), ${literal}) > 0`
+  );
+
+  return `where (${predicates.join('\n  or ')})`;
+}
+
+function getSearchableFields(service: LogsService) {
+  switch (service) {
+    case 'api':
+      return [
+        'id',
+        'identifier',
+        'event_message',
+        'request.method',
+        'request.path',
+        'response.status_code',
+      ];
+    case 'branch-action':
+      return ['id', 'workflow_run', 'event_message'];
+    case 'postgres':
+      return ['id', 'identifier', 'event_message', 'parsed.error_severity'];
+    case 'edge-function':
+      return [
+        'id',
+        'event_message',
+        'request.method',
+        'response.status_code',
+        'm.function_id',
+        'm.deployment_id',
+        'm.version',
+      ];
+    case 'auth':
+      return [
+        'id',
+        'event_message',
+        'metadata.level',
+        'metadata.status',
+        'metadata.path',
+        'metadata.msg',
+        'metadata.error',
+      ];
+    case 'storage':
+      return ['id', 'event_message'];
+    case 'realtime':
+      return ['id', 'event_message'];
+    default:
+      throw new Error(`unsupported log service type: ${service}`);
+  }
+}
+
+function sqlStringLiteral(value: string) {
+  return `'${value.replace(/'/g, "''")}'`;
 }

--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -239,10 +239,10 @@ export function createSupabaseApiPlatform(
 
   const debugging: DebuggingOperations = {
     async getLogs(projectId: string, options: GetLogsOptions) {
-      const { service, iso_timestamp_start, iso_timestamp_end } =
+      const { service, iso_timestamp_start, iso_timestamp_end, limit, search } =
         getLogsOptionsSchema.parse(options);
 
-      const sql = getLogQuery(service);
+      const sql = getLogQuery(service, { limit, search });
 
       const response = await managementApiClient.GET(
         '/v1/projects/{ref}/analytics/endpoints/logs.all',

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -145,6 +145,8 @@ export const getLogsOptionsSchema = z.object({
   service: logsServiceSchema,
   iso_timestamp_start: z.string().optional(),
   iso_timestamp_end: z.string().optional(),
+  limit: z.number().int().min(1).max(1000).optional(),
+  search: z.string().trim().min(1).max(256).optional(),
 });
 
 export const generateTypescriptTypesResultSchema = z.object({

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1446,6 +1446,41 @@ describe('tools', () => {
     }
   });
 
+  test('get logs forwards filtering options', async () => {
+    const getLogs = vi.fn(async () => [{ message: 'filtered log' }]);
+    const { callTool } = await setup({
+      features: ['debugging'],
+      platform: {
+        debugging: {
+          getLogs,
+          getSecurityAdvisors: vi.fn(),
+          getPerformanceAdvisors: vi.fn(),
+        },
+      },
+    });
+
+    const result = await callTool({
+      name: 'get_logs',
+      arguments: {
+        project_id: 'project-ref',
+        service: 'edge-function',
+        iso_timestamp_start: '2026-01-01T00:00:00.000Z',
+        iso_timestamp_end: '2026-01-01T00:05:00.000Z',
+        search: 'billing-worker',
+        limit: 25,
+      },
+    });
+
+    expect(result).toEqual({ result: [{ message: 'filtered log' }] });
+    expect(getLogs).toHaveBeenCalledWith('project-ref', {
+      service: 'edge-function',
+      iso_timestamp_start: '2026-01-01T00:00:00.000Z',
+      iso_timestamp_end: '2026-01-01T00:05:00.000Z',
+      search: 'billing-worker',
+      limit: 25,
+    });
+  });
+
   test('get security advisors', async () => {
     const { callTool } = await setup();
 

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -13,6 +13,39 @@ type DebuggingToolsOptions = {
 const getLogsInputSchema = z.object({
   project_id: z.string(),
   service: logsServiceSchema.describe('The service to fetch logs for'),
+  last_minutes: z
+    .number()
+    .int()
+    .min(1)
+    .max(1440)
+    .optional()
+    .describe(
+      'Fetch logs from the last N minutes. Defaults to the last 24 hours when no explicit start timestamp is provided.'
+    ),
+  iso_timestamp_start: z
+    .string()
+    .optional()
+    .describe('The ISO timestamp to start fetching logs from.'),
+  iso_timestamp_end: z
+    .string()
+    .optional()
+    .describe('The ISO timestamp to stop fetching logs at. Defaults to now.'),
+  search: z
+    .string()
+    .trim()
+    .min(1)
+    .max(256)
+    .optional()
+    .describe(
+      'Filters logs to rows containing this text in common log fields such as messages, paths, or edge function IDs.'
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .default(100)
+    .describe('Maximum number of log rows to return. Defaults to 100.'),
 });
 
 const getLogsOutputSchema = z.object({
@@ -33,7 +66,7 @@ const getAdvisorsOutputSchema = z.object({
 export const debuggingToolDefs = {
   get_logs: {
     description:
-      'Gets logs for a Supabase project by service type. Use this to help debug problems with your app. This will return logs within the last 24 hours.',
+      'Gets logs for a Supabase project by service type. Use this to help debug problems with your app. Defaults to the last 24 hours, with optional time window, search, and limit filters for focused debugging.',
     parameters: getLogsInputSchema,
     outputSchema: getLogsOutputSchema,
     annotations: {
@@ -69,14 +102,34 @@ export function getDebuggingTools({
     get_logs: injectableTool({
       ...debuggingToolDefs.get_logs,
       inject: { project_id },
-      execute: async ({ project_id, service }) => {
-        const startTimestamp = new Date(Date.now() - 24 * 60 * 60 * 1000); // Last 24 hours
-        const endTimestamp = new Date();
+      execute: async ({
+        project_id,
+        service,
+        last_minutes,
+        iso_timestamp_start,
+        iso_timestamp_end,
+        search,
+        limit,
+      }) => {
+        const endTimestamp = parseTimestamp(iso_timestamp_end) ?? new Date();
+        const startTimestamp =
+          parseTimestamp(iso_timestamp_start) ??
+          new Date(
+            endTimestamp.getTime() - (last_minutes ?? 24 * 60) * 60 * 1000
+          );
+
+        if (startTimestamp > endTimestamp) {
+          throw new Error(
+            'iso_timestamp_start must be before iso_timestamp_end.'
+          );
+        }
 
         const result = await debugging.getLogs(project_id, {
           service,
           iso_timestamp_start: startTimestamp.toISOString(),
           iso_timestamp_end: endTimestamp.toISOString(),
+          limit,
+          search,
         });
         return { result };
       },
@@ -100,4 +153,15 @@ export function getDebuggingTools({
       },
     }),
   };
+}
+
+function parseTimestamp(value?: string) {
+  if (!value) return undefined;
+
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`Invalid ISO timestamp: ${value}`);
+  }
+
+  return timestamp;
 }


### PR DESCRIPTION
## Summary

This adds focused filtering controls to the `get_logs` tool so clients can reduce noisy log output before sending it back to the model. The tool now accepts a short time window, explicit ISO timestamp bounds, a row limit, and a text search term for common log fields.

## Problem

`get_logs` previously always queried the last 24 hours with a fixed default query. On projects with many edge functions or high log volume, this makes debugging difficult because relevant entries can be buried under unrelated service output.

## Changes

- Added `last_minutes`, `iso_timestamp_start`, `iso_timestamp_end`, `search`, and `limit` parameters to `get_logs`.
- Passed the new filtering options through the platform layer into the Management API log query.
- Added searchable log predicates for service-specific fields such as event messages, request paths, auth metadata, and edge function identifiers.
- Added unit coverage for generated log SQL and MCP tool option forwarding.

Fixes #173.

## Validation

- `pnpm --filter @supabase/mcp-server-supabase typecheck`
- `CI=true pnpm --filter @supabase/mcp-server-supabase exec vitest --project unit --run src/logs.test.ts src/server.test.ts -t "get logs|LogQuery"`
- `pnpm exec biome check packages/mcp-server-supabase/src/logs.ts packages/mcp-server-supabase/src/logs.test.ts packages/mcp-server-supabase/src/platform/api-platform.ts packages/mcp-server-supabase/src/platform/types.ts packages/mcp-server-supabase/src/server.test.ts packages/mcp-server-supabase/src/tools/debugging-tools.ts`

The full Windows unit run still has existing path-related failures in `edge-function.test.ts` / edge-function server assertions, unrelated to this change.