### PR TITLE
Hide mutating tools from read-only tools/list

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -3017,7 +3017,7 @@ describe('tools', () => {
   });
 
   test('read-only mode excludes write tools from tools/list', async () => {
-    const { client } = await setup({
+    const { callTool, client } = await setup({
       readOnly: true,
       features: [
         'docs',
@@ -3046,6 +3046,19 @@ describe('tools', () => {
         .filter((tool) => tool.annotations?.readOnlyHint === false)
         .map((tool) => tool.name)
     ).toEqual([]);
+
+    const result = callTool({
+      name: 'apply_migration',
+      arguments: {
+        project_id: 'test-project-ref',
+        name: 'test-migration',
+        query: 'create table test (id int)',
+      },
+    });
+
+    await expect(result).rejects.toThrow(
+      'Cannot apply migration in read-only mode.'
+    );
   });
 
   test('tool result content is valid JSON', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -3016,6 +3016,38 @@ describe('tools', () => {
     }
   });
 
+  test('read-only mode excludes write tools from tools/list', async () => {
+    const { client } = await setup({
+      readOnly: true,
+      features: [
+        'docs',
+        'account',
+        'database',
+        'debugging',
+        'development',
+        'functions',
+        'branching',
+        'storage',
+      ],
+    });
+
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
+
+    expect(toolNames).toContain('execute_sql');
+    expect(toolNames).not.toContain('apply_migration');
+    expect(toolNames).not.toContain('deploy_edge_function');
+    expect(toolNames).not.toContain('create_branch');
+    expect(toolNames).not.toContain('delete_branch');
+    expect(toolNames).not.toContain('update_storage_config');
+
+    expect(
+      tools
+        .filter((tool) => tool.annotations?.readOnlyHint === false)
+        .map((tool) => tool.name)
+    ).toEqual([]);
+  });
+
   test('tool result content is valid JSON', async () => {
     const org = await createOrganization({
       name: 'My Org',

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -14,6 +14,7 @@ import { getDevelopmentTools } from './tools/development-tools.js';
 import { getDocsTools } from './tools/docs-tools.js';
 import { getEdgeFunctionTools } from './tools/edge-function-tools.js';
 import { getStorageTools } from './tools/storage-tools.js';
+import { writeToolSet } from './tools/tool-schemas.js';
 import type { FeatureGroup } from './types.js';
 import { parseFeatureGroups } from './util.js';
 
@@ -69,9 +70,7 @@ export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];
 
 function removeWriteTools(tools: Record<string, Tool>) {
   return Object.fromEntries(
-    Object.entries(tools).filter(
-      ([, tool]) => tool.annotations?.readOnlyHint !== false
-    )
+    Object.entries(tools).filter(([name]) => !writeToolSet.has(name))
   );
 }
 

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -67,6 +67,14 @@ const DEFAULT_FEATURES: FeatureGroup[] = [
 
 export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];
 
+function removeWriteTools(tools: Record<string, Tool>) {
+  return Object.fromEntries(
+    Object.entries(tools).filter(
+      ([, tool]) => tool.annotations?.readOnlyHint !== false
+    )
+  );
+}
+
 export const instructions = `
 Here are guidelines for using Supabase tools effectively:
 
@@ -114,6 +122,68 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     features ?? availableDefaultFeatures
   );
 
+  async function getTools() {
+    const contentApiClient = await contentApiClientPromise;
+    const tools: Record<string, Tool> = {};
+
+    const {
+      account,
+      database,
+      functions,
+      debugging,
+      development,
+      storage,
+      branching,
+    } = platform;
+
+    if (enabledFeatures.has('docs')) {
+      Object.assign(tools, getDocsTools({ contentApiClient }));
+    }
+
+    if (!projectId && account && enabledFeatures.has('account')) {
+      Object.assign(tools, getAccountTools({ account, readOnly }));
+    }
+
+    if (database && enabledFeatures.has('database')) {
+      Object.assign(
+        tools,
+        getDatabaseTools({
+          database,
+          projectId,
+          readOnly,
+        })
+      );
+    }
+
+    if (debugging && enabledFeatures.has('debugging')) {
+      Object.assign(tools, getDebuggingTools({ debugging, projectId }));
+    }
+
+    if (development && enabledFeatures.has('development')) {
+      Object.assign(tools, getDevelopmentTools({ development, projectId }));
+    }
+
+    if (functions && enabledFeatures.has('functions')) {
+      Object.assign(
+        tools,
+        getEdgeFunctionTools({ functions, projectId, readOnly })
+      );
+    }
+
+    if (branching && enabledFeatures.has('branching')) {
+      Object.assign(
+        tools,
+        getBranchingTools({ branching, projectId, readOnly })
+      );
+    }
+
+    if (storage && enabledFeatures.has('storage')) {
+      Object.assign(tools, getStorageTools({ storage, projectId, readOnly }));
+    }
+
+    return tools;
+  }
+
   const server = createMcpServer({
     name: 'supabase',
     title: 'Supabase',
@@ -133,66 +203,10 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       ]);
     },
     onToolCall,
-    tools: async () => {
-      const contentApiClient = await contentApiClientPromise;
-      const tools: Record<string, Tool> = {};
-
-      const {
-        account,
-        database,
-        functions,
-        debugging,
-        development,
-        storage,
-        branching,
-      } = platform;
-
-      if (enabledFeatures.has('docs')) {
-        Object.assign(tools, getDocsTools({ contentApiClient }));
-      }
-
-      if (!projectId && account && enabledFeatures.has('account')) {
-        Object.assign(tools, getAccountTools({ account, readOnly }));
-      }
-
-      if (database && enabledFeatures.has('database')) {
-        Object.assign(
-          tools,
-          getDatabaseTools({
-            database,
-            projectId,
-            readOnly,
-          })
-        );
-      }
-
-      if (debugging && enabledFeatures.has('debugging')) {
-        Object.assign(tools, getDebuggingTools({ debugging, projectId }));
-      }
-
-      if (development && enabledFeatures.has('development')) {
-        Object.assign(tools, getDevelopmentTools({ development, projectId }));
-      }
-
-      if (functions && enabledFeatures.has('functions')) {
-        Object.assign(
-          tools,
-          getEdgeFunctionTools({ functions, projectId, readOnly })
-        );
-      }
-
-      if (branching && enabledFeatures.has('branching')) {
-        Object.assign(
-          tools,
-          getBranchingTools({ branching, projectId, readOnly })
-        );
-      }
-
-      if (storage && enabledFeatures.has('storage')) {
-        Object.assign(tools, getStorageTools({ storage, projectId, readOnly }));
-      }
-
-      return tools;
+    tools: getTools,
+    listedTools: async () => {
+      const tools = await getTools();
+      return readOnly ? removeWriteTools(tools) : tools;
     },
   });
 

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.ts
@@ -133,7 +133,7 @@ const PROJECT_SCOPED_OVERRIDES: Record<string, SchemaEntry> =
  * Derived from tool defs: any tool with `readOnlyHint: false` and no
  * `readOnlyBehavior: 'adapt'` annotation.
  */
-const writeToolSet = new Set(
+export const writeToolSet = new Set(
   Object.entries(supabaseMcpToolSchemas)
     .filter(
       ([, entry]) =>

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -265,6 +265,15 @@ export type McpServerOptions = {
    * that can change after the server has started.
    */
   tools?: Prop<Record<string, Tool>>;
+
+  /**
+   * Optional tool subset to expose from `tools/list`.
+   *
+   * When omitted, `tools/list` uses the same tool set as tool calls. This lets
+   * servers hide tools from planning while still returning a clear runtime
+   * error if an older client calls a previously listed tool.
+   */
+  listedTools?: Prop<Record<string, Tool>>;
 };
 
 /**
@@ -314,6 +323,17 @@ export function createMcpServer(options: McpServerOptions) {
     return typeof options.tools === 'function'
       ? await options.tools()
       : options.tools;
+  }
+
+  async function getListedTools() {
+    if (!options.tools) {
+      throw new Error('tools not available');
+    }
+
+    const listedTools = options.listedTools ?? options.tools;
+    return typeof listedTools === 'function'
+      ? await listedTools()
+      : listedTools;
   }
 
   server.oninitialized = async () => {
@@ -449,7 +469,7 @@ export function createMcpServer(options: McpServerOptions) {
     server.setRequestHandler(
       ListToolsRequestSchema,
       async (): Promise<ListToolsResult> => {
-        const tools = await getTools();
+        const tools = await getListedTools();
 
         return {
           tools: await Promise.all(


### PR DESCRIPTION
## Summary
- add an optional `listedTools` subset to `createMcpServer` so `tools/list` can differ from callable tools
- use that subset in Supabase read-only mode to hide write tools from MCP clients while preserving existing runtime read-only errors for stale callers
- add a regression test that verifies read-only `tools/list` contains no `readOnlyHint: false` tools

Fixes #281.

## Verification
- pnpm --filter @supabase/mcp-utils typecheck
- pnpm --filter @supabase/mcp-utils build
- pnpm --filter @supabase/mcp-server-supabase typecheck
- CI=1 pnpm --filter @supabase/mcp-server-supabase exec vitest run --project unit src/server.test.ts -t "read-only mode excludes write tools from tools/list"
- CI=1 pnpm --filter @supabase/mcp-server-supabase exec vitest run --project unit src/server.test.ts -t "cannot apply migration in read-only mode"
- pnpm exec biome check packages/mcp-utils/src/server.ts packages/mcp-server-supabase/src/server.ts packages/mcp-server-supabase/src/server.test.ts
- pnpm --filter @supabase/mcp-server-supabase build

Note: the full `src/server.test.ts` suite still hits the existing `delete branch` failure tracked by #282 / #279 on current main.