### PR TITLE
docs: add Clarvia AEO badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![MCP Registry Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fcom.supabase%252Fmcp%2Fversions%2Flatest&query=%24.server.version&label=MCP%20Registry&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=com.supabase%2Fmcp)
 
+[![AEO Score](https://clarvia.art/api/badge/supabase-mcp)](https://clarvia.art/tool/supabase-mcp)
+
 > Connect your Supabase projects to Cursor, Claude, Windsurf, and other AI assistants.
 
 ![supabase-mcp-demo](https://github.com/user-attachments/assets/3fce101a-b7d4-482f-9182-0be70ed1ad56)


### PR DESCRIPTION
## Summary

Adds the Clarvia AEO badge to the README as requested in #248.

The badge links to the Supabase MCP profile on Clarvia and automatically reflects the latest agent-readiness score.

Closes #248
