### PR TITLE
fix: update repo URLs after `supabase/mcp` transfer

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   preview:
     if: >
-      github.repository == 'supabase-community/supabase-mcp' &&
+      github.repository == 'supabase/mcp' &&
       github.event_name == 'pull_request' &&
       contains(github.event.pull_request.labels.*.name, 'publish-preview')
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
 
 Most contributors don't need to do anything beyond merging the release PR and updating downstream apps.
 
-If the release PR gets into a bad state, close it and manually re-run the workflow from the [Actions tab](https://github.com/supabase-community/supabase-mcp/actions/workflows/release.yml) → **Run workflow**. release-please will recreate the PR from scratch.
+If the release PR gets into a bad state, close it and manually re-run the workflow from the [Actions tab](https://github.com/supabase/mcp/actions/workflows/release.yml) → **Run workflow**. release-please will recreate the PR from scratch.
 
 ## Manual MCP registry publish (optional)
 

--- a/packages/mcp-server-postgrest/package.json
+++ b/packages/mcp-server-postgrest/package.json
@@ -7,10 +7,6 @@
     "type": "git",
     "url": "https://github.com/supabase/mcp.git"
   },
-  "homepage": "https://github.com/supabase/mcp/tree/main/packages/mcp-server-postgrest#readme",
-  "bugs": {
-    "url": "https://github.com/supabase/mcp/issues"
-  },
   "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server-postgrest/package.json
+++ b/packages/mcp-server-postgrest/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/supabase-community/supabase-mcp.git"
+    "url": "https://github.com/supabase/mcp.git"
+  },
+  "homepage": "https://github.com/supabase/mcp/tree/main/packages/mcp-server-postgrest#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/mcp/issues"
   },
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -6,7 +6,11 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/supabase-community/supabase-mcp.git"
+    "url": "https://github.com/supabase/mcp.git"
+  },
+  "homepage": "https://github.com/supabase/mcp#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/mcp/issues"
   },
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -8,10 +8,6 @@
     "type": "git",
     "url": "https://github.com/supabase/mcp.git"
   },
-  "homepage": "https://github.com/supabase/mcp#readme",
-  "bugs": {
-    "url": "https://github.com/supabase/mcp/issues"
-  },
   "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server-supabase/server.json
+++ b/packages/mcp-server-supabase/server.json
@@ -55,7 +55,7 @@
     }
   ],
   "repository": {
-    "url": "https://github.com/supabase-community/supabase-mcp",
+    "url": "https://github.com/supabase/mcp",
     "source": "github",
     "subfolder": "packages/mcp-server-supabase"
   },

--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -1958,6 +1958,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/projects/{ref}/database/backups/schedule": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets the backup schedule for a project */
+        get: operations["v1-get-backup-schedule"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Updates the backup schedule time for a project
+         * @description Sets the time at which the daily backup runs. The change takes effect on the next backup window that includes the new time. If the new time has already passed for today, the first backup at the new time will occur the following day. It can only be updated 3 times per 24 hours.
+         */
+        patch: operations["v1-update-backup-schedule"];
+        trace?: never;
+    };
     "/v1/projects/{ref}/database/backups/undo": {
         parameters: {
             query?: never;
@@ -2127,7 +2148,11 @@ export interface components {
              */
             latest_check_run_id?: number;
             persistent: boolean;
-            /** @enum {string} */
+            /**
+             * @deprecated
+             * @description This field is deprecated. List action runs to get branch status instead.
+             * @enum {string}
+             */
             status: "CREATING_PROJECT" | "RUNNING_MIGRATIONS" | "MIGRATIONS_PASSED" | "MIGRATIONS_FAILED" | "FUNCTIONS_DEPLOYED" | "FUNCTIONS_FAILED";
             /** Format: date-time */
             created_at: string;
@@ -2973,7 +2998,14 @@ export interface components {
             } | {
                 /** @enum {string} */
                 type: "x86_architecture";
+            } | {
+                /** @enum {string} */
+                type: "project_hibernating";
             })[];
+            warnings: {
+                /** @enum {string} */
+                type: "pg_graphql_introspection_change";
+            }[];
         };
         DatabaseUpgradeStatusResponse: {
             databaseUpgradeStatus: {
@@ -4318,6 +4350,19 @@ export interface components {
         PostgresConfigResponse: {
             effective_cache_size?: string;
             logical_decoding_work_mem?: string;
+            "cron.log_statement"?: boolean;
+            /** @description Default unit: ms */
+            log_autovacuum_min_duration?: string;
+            log_checkpoints?: boolean;
+            log_connections?: boolean;
+            log_disconnections?: boolean;
+            log_duration?: boolean;
+            log_lock_waits?: boolean;
+            log_recovery_conflict_waits?: boolean;
+            log_replication_commands?: boolean;
+            /** @description Default unit: ms */
+            log_startup_progress_interval?: string;
+            log_temp_files?: string;
             maintenance_work_mem?: string;
             track_activity_query_size?: string;
             max_connections?: number;
@@ -4355,6 +4400,19 @@ export interface components {
         UpdatePostgresConfigBody: {
             effective_cache_size?: string;
             logical_decoding_work_mem?: string;
+            "cron.log_statement"?: boolean;
+            /** @description Default unit: ms */
+            log_autovacuum_min_duration?: string;
+            log_checkpoints?: boolean;
+            log_connections?: boolean;
+            log_disconnections?: boolean;
+            log_duration?: boolean;
+            log_lock_waits?: boolean;
+            log_recovery_conflict_waits?: boolean;
+            log_replication_commands?: boolean;
+            /** @description Default unit: ms */
+            log_startup_progress_interval?: string;
+            log_temp_files?: string;
             maintenance_work_mem?: string;
             track_activity_query_size?: string;
             max_connections?: number;
@@ -4692,6 +4750,29 @@ export interface components {
         V1RestoreBackupBody: {
             id: number;
         };
+        V1BackupScheduleResponse: {
+            /**
+             * @description Time of day to schedule daily backups, in UTC. Format: HH:MM:SS.
+             * @example 04:00:00
+             */
+            schedule_for: string;
+            /**
+             * Format: date-time
+             * @description Timestamp of when the backup schedule was last updated.
+             * @example 2026-05-04T14:40:44+00:00
+             */
+            updated_at: string;
+        };
+        /** @example {
+         *       "schedule_for": "04:00:00"
+         *     } */
+        V1UpdateBackupScheduleBody: {
+            /**
+             * @description Time of day to schedule daily backups, in UTC. Format: HH:MM:SS.
+             * @example 04:00:00
+             */
+            schedule_for: string;
+        };
         /** @example {
          *       "name": "before-upgrade"
          *     } */
@@ -4702,7 +4783,7 @@ export interface components {
             entitlements: {
                 feature: {
                     /** @enum {string} */
-                    key: "instances.compute_update_available_sizes" | "instances.read_replicas" | "instances.disk_modifications" | "instances.high_availability" | "instances.orioledb" | "replication.etl" | "storage.max_file_size" | "storage.max_file_size.configurable" | "storage.image_transformations" | "storage.vector_buckets" | "storage.iceberg_catalog" | "security.audit_logs_days" | "security.questionnaire" | "security.soc2_report" | "security.iso27001_certificate" | "security.private_link" | "security.enforce_mfa" | "log.retention_days" | "custom_domain" | "vanity_subdomain" | "ipv4" | "pitr.available_variants" | "log_drains" | "branching_limit" | "branching_persistent" | "auth.mfa_phone" | "auth.mfa_web_authn" | "auth.mfa_enhanced_security" | "auth.hooks" | "auth.platform.sso" | "auth.custom_jwt_template" | "auth.saml_2" | "auth.user_sessions" | "auth.leaked_password_protection" | "auth.advanced_auth_settings" | "auth.performance_settings" | "auth.password_hibp" | "auth.custom_oauth.max_providers" | "backup.retention_days" | "backup.restore_to_new_project" | "function.max_count" | "function.size_limit_mb" | "realtime.max_concurrent_users" | "realtime.max_events_per_second" | "realtime.max_joins_per_second" | "realtime.max_channels_per_client" | "realtime.max_bytes_per_second" | "realtime.max_presence_events_per_second" | "realtime.max_payload_size_in_kb" | "project_scoped_roles" | "security.member_roles" | "project_pausing" | "project_cloning" | "project_restore_after_expiry" | "assistant.advance_model" | "integrations.github_connections" | "dedicated_pooler" | "observability.dashboard_advanced_metrics";
+                    key: "instances.compute_update_available_sizes" | "instances.read_replicas" | "instances.disk_modifications" | "instances.high_availability" | "instances.orioledb" | "replication.etl" | "storage.max_file_size" | "storage.max_file_size.configurable" | "storage.image_transformations" | "storage.vector_buckets" | "storage.iceberg_catalog" | "security.audit_logs_days" | "security.questionnaire" | "security.soc2_report" | "security.iso27001_certificate" | "security.private_link" | "security.enforce_mfa" | "log.retention_days" | "custom_domain" | "vanity_subdomain" | "ipv4" | "pitr.available_variants" | "log_drains" | "audit_log_drains" | "branching_limit" | "branching_persistent" | "auth.mfa_phone" | "auth.mfa_web_authn" | "auth.mfa_enhanced_security" | "auth.hooks" | "auth.platform.sso" | "auth.custom_jwt_template" | "auth.saml_2" | "auth.user_sessions" | "auth.leaked_password_protection" | "auth.advanced_auth_settings" | "auth.performance_settings" | "auth.password_hibp" | "auth.custom_oauth.max_providers" | "backup.retention_days" | "backup.restore_to_new_project" | "backup.schedule" | "function.max_count" | "function.size_limit_mb" | "realtime.max_concurrent_users" | "realtime.max_events_per_second" | "realtime.max_joins_per_second" | "realtime.max_channels_per_client" | "realtime.max_bytes_per_second" | "realtime.max_presence_events_per_second" | "realtime.max_payload_size_in_kb" | "project_scoped_roles" | "security.member_roles" | "project_pausing" | "project_cloning" | "project_restore_after_expiry" | "assistant.advance_model" | "integrations.github_connections" | "dedicated_pooler" | "observability.dashboard_advanced_metrics";
                     /** @enum {string} */
                     type: "boolean" | "numeric" | "set";
                 };
@@ -5321,7 +5402,7 @@ export interface operations {
             };
         };
         responses: {
-            201: {
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -7612,6 +7693,13 @@ export interface operations {
                     "application/json": components["schemas"]["VanitySubdomainConfigResponse"];
                 };
             };
+            /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Unauthorized */
             401: {
                 headers: {
@@ -7714,6 +7802,13 @@ export interface operations {
                     "application/json": components["schemas"]["SubdomainAvailabilityResponse"];
                 };
             };
+            /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Unauthorized */
             401: {
                 headers: {
@@ -7767,6 +7862,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ActivateVanitySubdomainResponse"];
                 };
+            };
+            /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Unauthorized */
             401: {
@@ -8076,6 +8178,13 @@ export interface operations {
             };
             /** @description Unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description This feature requires the Pro, Team, or Enterprise organization plan. */
+            402: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -12228,6 +12337,145 @@ export interface operations {
             };
             /** @description Rate limit exceeded */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-get-backup-schedule": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V1BackupScheduleResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description This feature requires the Enterprise organization plan. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Project or backup schedule not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to retrieve backup schedule */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    "v1-update-backup-schedule": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Project ref */
+                ref: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["V1UpdateBackupScheduleBody"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V1BackupScheduleResponse"];
+                };
+            };
+            /** @description Invalid schedule_for format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description This feature requires the Enterprise organization plan. */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden action */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Project or backup schedule not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Rate limit exceeded */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to update backup schedule */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -7,10 +7,6 @@
     "type": "git",
     "url": "https://github.com/supabase/mcp.git"
   },
-  "homepage": "https://github.com/supabase/mcp/tree/main/packages/mcp-utils#readme",
-  "bugs": {
-    "url": "https://github.com/supabase/mcp/issues"
-  },
   "type": "module",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",

--- a/packages/mcp-utils/package.json
+++ b/packages/mcp-utils/package.json
@@ -5,7 +5,11 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/supabase-community/supabase-mcp.git"
+    "url": "https://github.com/supabase/mcp.git"
+  },
+  "homepage": "https://github.com/supabase/mcp/tree/main/packages/mcp-utils#readme",
+  "bugs": {
+    "url": "https://github.com/supabase/mcp/issues"
   },
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
This repo transferred from `supabase-community/supabase-mcp` -> `supabase/mcp`. This updates references to the old path. Also regenerates mgmt-api types to satisfy PR checks.

I'm treating this as a `fix:` to trigger a new patch release, so consumers see the correct URL in published NPM artifacts and so we can update the MCP registry.

Ref: AI-792