### PR TITLE
Fix stdio CLI help and parse errors

### DIFF
--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -10,38 +10,66 @@ import { parseList } from './util.js';
 const { version } = packageJson;
 
 async function main() {
+  let values: {
+    ['access-token']?: string;
+    ['project-ref']?: string;
+    ['read-only']?: boolean;
+    ['api-url']?: string;
+    ['version']?: boolean;
+    ['help']?: boolean;
+    ['features']?: string;
+  };
+
+  try {
+    ({ values } = parseArgs({
+      options: {
+        ['access-token']: {
+          type: 'string',
+        },
+        ['project-ref']: {
+          type: 'string',
+        },
+        ['read-only']: {
+          type: 'boolean',
+          default: false,
+        },
+        ['api-url']: {
+          type: 'string',
+        },
+        ['version']: {
+          type: 'boolean',
+        },
+        ['help']: {
+          type: 'boolean',
+          short: 'h',
+        },
+        ['features']: {
+          type: 'string',
+        },
+      },
+    }));
+  } catch (error) {
+    if (isParseArgsError(error)) {
+      console.error(error.message);
+      process.exit(1);
+    }
+    throw error;
+  }
+
   const {
-    values: {
-      ['access-token']: cliAccessToken,
-      ['project-ref']: projectId,
-      ['read-only']: readOnly,
-      ['api-url']: apiUrl,
-      ['version']: showVersion,
-      ['features']: cliFeatures,
-    },
-  } = parseArgs({
-    options: {
-      ['access-token']: {
-        type: 'string',
-      },
-      ['project-ref']: {
-        type: 'string',
-      },
-      ['read-only']: {
-        type: 'boolean',
-        default: false,
-      },
-      ['api-url']: {
-        type: 'string',
-      },
-      ['version']: {
-        type: 'boolean',
-      },
-      ['features']: {
-        type: 'string',
-      },
-    },
-  });
+    ['access-token']: cliAccessToken,
+    ['project-ref']: projectId,
+    ['read-only']: readOnly,
+    ['api-url']: apiUrl,
+    ['version']: showVersion,
+    ['help']: showHelp,
+    ['features']: cliFeatures,
+  } = values;
+
+  if (showHelp) {
+    printHelp();
+    process.exit(0);
+  }
 
   if (showVersion) {
     console.log(version);
@@ -76,4 +104,28 @@ async function main() {
   await server.connect(transport);
 }
 
-main().catch(console.error);
+function printHelp() {
+  console.log(`Usage: mcp-server-supabase [options]
+
+Options:
+  --access-token <token>  Supabase personal access token
+  --project-ref <ref>     Scope the server to a project ref
+  --read-only             Prevent write operations
+  --api-url <url>         Supabase API URL
+  --features <list>       Comma-separated feature list
+  --version               Print the package version
+  -h, --help              Display help`);
+}
+
+function isParseArgsError(error: unknown): error is Error & { code: string } {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    error.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/mcp-server-supabase/test/stdio.integration.ts
+++ b/packages/mcp-server-supabase/test/stdio.integration.ts
@@ -3,6 +3,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { describe, expect, test } from 'vitest';
 import { ACCESS_TOKEN, MCP_CLIENT_NAME, MCP_CLIENT_VERSION } from './mocks.js';
 import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { spawnSync } from 'node:child_process';
 
 type SetupOptions = {
   accessToken?: string;
@@ -58,6 +59,41 @@ async function setup(options: SetupOptions = {}) {
 }
 
 describe('stdio', () => {
+  test('prints help without starting the server', () => {
+    for (const flag of ['--help', '-h']) {
+      const result = spawnSync(
+        process.execPath,
+        ['dist/transports/stdio.js', flag],
+        {
+          encoding: 'utf8',
+        }
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Usage: mcp-server-supabase');
+      expect(result.stdout).toContain('--access-token');
+      expect(result.stdout).toContain('--version');
+      expect(result.stderr).toBe('');
+    }
+  });
+
+  test('prints a concise error for unknown flags', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['dist/transports/stdio.js', '--definitely-not-a-real-flag'],
+      {
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      "Unknown option '--definitely-not-a-real-flag'"
+    );
+    expect(result.stderr).not.toContain('ERR_PARSE_ARGS_UNKNOWN_OPTION');
+  });
+
   test('server connects and lists tools', async () => {
     const { client } = await setup();
 


### PR DESCRIPTION
## Summary
- add `--help` / `-h` handling for the Supabase MCP stdio CLI before server startup
- normalize unknown top-level flag parse errors to a concise stderr message and exit 1
- add integration coverage for help output and unknown flag behavior

Closes #296.

## Validation
- Red test first: `CI=1 npx --yes pnpm@10.33.2 --filter @supabase/mcp-server-supabase exec vitest run --project integration test/stdio.integration.ts` failed on the new help/unknown-flag assertions before the fix
- `npx --yes pnpm@10.33.2 --filter @supabase/mcp-utils build`
- `npx --yes pnpm@10.33.2 --filter @supabase/mcp-server-supabase build`
- `CI=1 npx --yes pnpm@10.33.2 --filter @supabase/mcp-server-supabase test:unit`
- `CI=1 npx --yes pnpm@10.33.2 --filter @supabase/mcp-server-supabase exec vitest run --project integration test/stdio.integration.ts`
- `npx --yes pnpm@10.33.2 format:check`
- dist smoke: `--help` and `-h` exit 0 and print usage
- dist smoke: `--version` exits 0 and prints `0.8.2`
- dist smoke: unknown flag exits 1 and does not print `ERR_PARSE_ARGS_UNKNOWN_OPTION`
- `git diff --check`

I also ran the full package `test` command. Unit and integration coverage passed, while the e2e tests failed because `ANTHROPIC_API_KEY` is not available in my local environment.