### PR TITLE
fix: add help output for supabase stdio CLI

### DIFF
--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -9,39 +9,72 @@ import { parseList } from './util.js';
 
 const { version } = packageJson;
 
+const helpText = `Usage: mcp-server-supabase [options]
+
+Options:
+  --access-token <token>  Supabase personal access token
+  --project-ref <ref>     Supabase project ref
+  --read-only             Restrict the server to read-only tools
+  --api-url <url>         Supabase API URL
+  --features <features>   Comma-separated feature list
+  --version               Print version information
+  -h, --help              Print this help message`;
+
+function parseCliArgs() {
+  try {
+    return parseArgs({
+      options: {
+        ['access-token']: {
+          type: 'string',
+        },
+        ['project-ref']: {
+          type: 'string',
+        },
+        ['read-only']: {
+          type: 'boolean',
+          default: false,
+        },
+        ['api-url']: {
+          type: 'string',
+        },
+        ['version']: {
+          type: 'boolean',
+        },
+        ['features']: {
+          type: 'string',
+        },
+        help: {
+          type: 'boolean',
+          short: 'h',
+        },
+      },
+    }).values;
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+      console.error(helpText);
+      process.exit(1);
+    }
+
+    throw error;
+  }
+}
+
 async function main() {
   const {
-    values: {
-      ['access-token']: cliAccessToken,
-      ['project-ref']: projectId,
-      ['read-only']: readOnly,
-      ['api-url']: apiUrl,
-      ['version']: showVersion,
-      ['features']: cliFeatures,
-    },
-  } = parseArgs({
-    options: {
-      ['access-token']: {
-        type: 'string',
-      },
-      ['project-ref']: {
-        type: 'string',
-      },
-      ['read-only']: {
-        type: 'boolean',
-        default: false,
-      },
-      ['api-url']: {
-        type: 'string',
-      },
-      ['version']: {
-        type: 'boolean',
-      },
-      ['features']: {
-        type: 'string',
-      },
-    },
-  });
+    ['access-token']: cliAccessToken,
+    ['project-ref']: projectId,
+    ['read-only']: readOnly,
+    ['api-url']: apiUrl,
+    ['version']: showVersion,
+    ['features']: cliFeatures,
+    help: showHelp,
+  } = parseCliArgs();
+
+  if (showHelp) {
+    console.log(helpText);
+    process.exit(0);
+  }
 
   if (showVersion) {
     console.log(version);

--- a/packages/mcp-server-supabase/test/stdio.integration.ts
+++ b/packages/mcp-server-supabase/test/stdio.integration.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, test } from 'vitest';
@@ -57,6 +58,12 @@ async function setup(options: SetupOptions = {}) {
   return { client, clientTransport };
 }
 
+function runStdioCli(args: string[]) {
+  return spawnSync('node', ['dist/transports/stdio.js', ...args], {
+    encoding: 'utf8',
+  });
+}
+
 describe('stdio', () => {
   test('server connects and lists tools', async () => {
     const { client } = await setup();
@@ -70,5 +77,28 @@ describe('stdio', () => {
     const setupPromise = setup({ accessToken: null as any });
 
     await expect(setupPromise).rejects.toThrow('MCP error -32000');
+  });
+
+  test('prints help for long and short flags', () => {
+    for (const flag of ['--help', '-h']) {
+      const result = runStdioCli([flag]);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Usage: mcp-server-supabase [options]');
+      expect(result.stdout).toContain('--access-token <token>');
+      expect(result.stdout).toContain('-h, --help');
+      expect(result.stderr).toBe('');
+    }
+  });
+
+  test('rejects unknown flags without a stack trace', () => {
+    const result = runStdioCli(['--unknown-flag']);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain("Unknown option '--unknown-flag'");
+    expect(result.stderr).toContain('Usage: mcp-server-supabase [options]');
+    expect(result.stderr).not.toContain('ERR_PARSE_ARGS_UNKNOWN_OPTION');
+    expect(result.stderr).not.toContain('TypeError');
   });
 });


### PR DESCRIPTION
## Summary
- add `--help` and `-h` output for the Supabase stdio CLI
- convert `parseArgs` failures into a concise error plus usage text with exit code 1
- add stdio integration coverage for help and unknown flags

Closes #296.

## Testing
- `npx -y pnpm@10 build`
- `CI=true npx -y pnpm@10 --filter @supabase/mcp-server-supabase test:integration -- test/stdio.integration.ts --run`
- `npx -y pnpm@10 exec biome check packages/mcp-server-supabase/src/transports/stdio.ts packages/mcp-server-supabase/test/stdio.integration.ts`
- `node packages/mcp-server-supabase/dist/transports/stdio.js --help`
- `node packages/mcp-server-supabase/dist/transports/stdio.js --unknown-flag`