### PR TITLE
fix: add stdio cli help handling

### DIFF
--- a/packages/mcp-server-supabase/src/transports/stdio-cli.test.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio-cli.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import packageJson from '../../package.json' with { type: 'json' };
+import { parseStdioCliArgs } from './stdio-cli.js';
+
+describe('parseStdioCliArgs', () => {
+  const originalAccessToken = process.env.SUPABASE_ACCESS_TOKEN;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (originalAccessToken === undefined) {
+      delete process.env.SUPABASE_ACCESS_TOKEN;
+    } else {
+      process.env.SUPABASE_ACCESS_TOKEN = originalAccessToken;
+    }
+  });
+
+  test.each([['--help'], ['-h']])('prints help for %s', (arg) => {
+    expect(parseStdioCliArgs([arg])).toEqual({
+      type: 'exit',
+      code: 0,
+      output: expect.stringContaining('Usage: mcp-server-supabase'),
+      stream: 'stdout',
+    });
+  });
+
+  test('prints version', () => {
+    expect(parseStdioCliArgs(['--version'])).toEqual({
+      type: 'exit',
+      code: 0,
+      output: `${packageJson.version}\n`,
+      stream: 'stdout',
+    });
+  });
+
+  test('normalizes unknown option errors', () => {
+    expect(parseStdioCliArgs(['--definitely-not-real'])).toEqual({
+      type: 'exit',
+      code: 1,
+      output: expect.stringContaining("Unknown option '--definitely-not-real'"),
+      stream: 'stderr',
+    });
+  });
+
+  test('parses server startup options', () => {
+    expect(
+      parseStdioCliArgs([
+        '--access-token',
+        'token-from-cli',
+        '--project-ref',
+        'project-ref',
+        '--read-only',
+        '--api-url',
+        'https://api.example.test',
+        '--features',
+        'database,docs',
+      ])
+    ).toEqual({
+      type: 'run',
+      options: {
+        accessToken: 'token-from-cli',
+        projectId: 'project-ref',
+        readOnly: true,
+        apiUrl: 'https://api.example.test',
+        features: ['database', 'docs'],
+      },
+    });
+  });
+
+  test('falls back to SUPABASE_ACCESS_TOKEN', () => {
+    vi.stubEnv('SUPABASE_ACCESS_TOKEN', 'token-from-env');
+
+    expect(parseStdioCliArgs([])).toEqual({
+      type: 'run',
+      options: {
+        accessToken: 'token-from-env',
+        projectId: undefined,
+        readOnly: false,
+        apiUrl: undefined,
+        features: undefined,
+      },
+    });
+  });
+});

--- a/packages/mcp-server-supabase/src/transports/stdio-cli.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio-cli.ts
@@ -1,0 +1,112 @@
+import { parseArgs } from 'node:util';
+import packageJson from '../../package.json' with { type: 'json' };
+import { parseList } from './util.js';
+
+const { version } = packageJson;
+
+const helpText = `Usage: mcp-server-supabase [options]
+
+Options:
+  --access-token <token>  Supabase personal access token
+  --project-ref <ref>     Supabase project ref
+  --read-only             Disable write tools
+  --api-url <url>         Supabase management API URL
+  --features <features>   Comma-separated feature groups to enable
+  --version               Print version
+  -h, --help              Print help
+`;
+
+type CliResult =
+  | { type: 'run'; options: StdioCliOptions }
+  | { type: 'exit'; code: number; output: string; stream: 'stdout' | 'stderr' };
+
+export type StdioCliOptions = {
+  accessToken?: string;
+  projectId?: string;
+  readOnly: boolean;
+  apiUrl?: string;
+  features?: string[];
+};
+
+export function parseStdioCliArgs(args = process.argv.slice(2)): CliResult {
+  try {
+    const {
+      values: {
+        ['access-token']: cliAccessToken,
+        ['project-ref']: projectId,
+        ['read-only']: readOnly = false,
+        ['api-url']: apiUrl,
+        ['version']: showVersion,
+        ['features']: cliFeatures,
+        ['help']: showHelp,
+      },
+    } = parseArgs({
+      args,
+      options: {
+        ['access-token']: {
+          type: 'string',
+        },
+        ['project-ref']: {
+          type: 'string',
+        },
+        ['read-only']: {
+          type: 'boolean',
+          default: false,
+        },
+        ['api-url']: {
+          type: 'string',
+        },
+        ['version']: {
+          type: 'boolean',
+        },
+        ['features']: {
+          type: 'string',
+        },
+        ['help']: {
+          type: 'boolean',
+          short: 'h',
+        },
+      },
+    });
+
+    if (showHelp) {
+      return { type: 'exit', code: 0, output: helpText, stream: 'stdout' };
+    }
+
+    if (showVersion) {
+      return {
+        type: 'exit',
+        code: 0,
+        output: `${version}\n`,
+        stream: 'stdout',
+      };
+    }
+
+    return {
+      type: 'run',
+      options: {
+        accessToken: cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN,
+        projectId,
+        readOnly,
+        apiUrl,
+        features: cliFeatures ? parseList(cliFeatures) : undefined,
+      },
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      type: 'exit',
+      code: 1,
+      output: `${message}\n\n${helpText}`,
+      stream: 'stderr',
+    };
+  }
+}
+
+export function writeCliExit(
+  result: Extract<CliResult, { type: 'exit' }>
+): never {
+  const writer = result.stream === 'stdout' ? process.stdout : process.stderr;
+  writer.write(result.output);
+  process.exit(result.code);
+}

--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -1,54 +1,17 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { parseArgs } from 'node:util';
-import packageJson from '../../package.json' with { type: 'json' };
 import { createSupabaseApiPlatform } from '../platform/api-platform.js';
 import { createSupabaseMcpServer } from '../server.js';
-import { parseList } from './util.js';
-
-const { version } = packageJson;
+import { parseStdioCliArgs, writeCliExit } from './stdio-cli.js';
 
 async function main() {
-  const {
-    values: {
-      ['access-token']: cliAccessToken,
-      ['project-ref']: projectId,
-      ['read-only']: readOnly,
-      ['api-url']: apiUrl,
-      ['version']: showVersion,
-      ['features']: cliFeatures,
-    },
-  } = parseArgs({
-    options: {
-      ['access-token']: {
-        type: 'string',
-      },
-      ['project-ref']: {
-        type: 'string',
-      },
-      ['read-only']: {
-        type: 'boolean',
-        default: false,
-      },
-      ['api-url']: {
-        type: 'string',
-      },
-      ['version']: {
-        type: 'boolean',
-      },
-      ['features']: {
-        type: 'string',
-      },
-    },
-  });
-
-  if (showVersion) {
-    console.log(version);
-    process.exit(0);
+  const cli = parseStdioCliArgs();
+  if (cli.type === 'exit') {
+    writeCliExit(cli);
   }
 
-  const accessToken = cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
+  const { accessToken, projectId, readOnly, apiUrl, features } = cli.options;
 
   if (!accessToken) {
     console.error(
@@ -56,8 +19,6 @@ async function main() {
     );
     process.exit(1);
   }
-
-  const features = cliFeatures ? parseList(cliFeatures) : undefined;
 
   const platform = createSupabaseApiPlatform({
     accessToken,


### PR DESCRIPTION
## Summary

- Add explicit `--help` / `-h` handling for the Supabase stdio CLI.
- Keep `--version` behavior while moving CLI metadata parsing into a small helper.
- Normalize unknown top-level options into a concise non-zero CLI error instead of printing a raw `parseArgs` stack trace and exiting 0.

Fixes #296.

## Verification

- From `packages/mcp-utils`: `.\node_modules\.bin\tsup.cmd --config tsup.config.ts`
- With `CI=1`, from `packages/mcp-server-supabase`: `.\node_modules\.bin\vitest.cmd run --project unit src/transports/stdio-cli.test.ts`
- From `packages/mcp-server-supabase`: `.\node_modules\.bin\tsc.cmd --noEmit`
- From `packages/mcp-server-supabase`: `.\node_modules\.bin\tsup.cmd --config tsup.config.ts`
- From repo root: `.\node_modules\.bin\biome.cmd check packages/mcp-server-supabase/src/transports/stdio.ts packages/mcp-server-supabase/src/transports/stdio-cli.ts packages/mcp-server-supabase/src/transports/stdio-cli.test.ts`
- `git diff --check`
- `node dist\transports\stdio.js --help`
- `node dist\transports\stdio.js --version`
- `node dist\transports\stdio.js --definitely-not-real`
- `node dist\transports\stdio.js` still requires a Supabase PAT for normal server startup.

Note: `corepack pnpm install --frozen-lockfile` mostly installed dependencies but exited non-zero locally because pnpm 11 blocked dependency build scripts and could not create the `supabase` binary. The package tests/builds above were run directly from the installed local package binaries after install.