### PR TITLE
Handle Supabase stdio CLI help flags

### DIFF
--- a/packages/mcp-server-supabase/src/transports/stdio-cli.test.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio-cli.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import { parseStdioCliArgs } from './stdio-cli.js';
+
+describe('parseStdioCliArgs', () => {
+  test('prints help without starting the server', () => {
+    const result = parseStdioCliArgs(['--help'], '0.8.2');
+
+    expect(result.action).toBe('exit');
+    if (result.action !== 'exit') {
+      throw new Error('Expected CLI parsing to exit');
+    }
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage: mcp-server-supabase [options]');
+    expect(result.stdout).toContain('--access-token');
+    expect(result.stderr).toBeUndefined();
+  });
+
+  test('prints help for the short help flag', () => {
+    const result = parseStdioCliArgs(['-h'], '0.8.2');
+
+    expect(result.action).toBe('exit');
+    if (result.action !== 'exit') {
+      throw new Error('Expected CLI parsing to exit');
+    }
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Usage: mcp-server-supabase [options]');
+  });
+
+  test('prints the package version', () => {
+    const result = parseStdioCliArgs(['--version'], '0.8.2');
+
+    expect(result).toEqual({
+      action: 'exit',
+      exitCode: 0,
+      stdout: '0.8.2\n',
+    });
+  });
+
+  test('prints the package version for the short version flag', () => {
+    const result = parseStdioCliArgs(['-v'], '0.8.2');
+
+    expect(result).toEqual({
+      action: 'exit',
+      exitCode: 0,
+      stdout: '0.8.2\n',
+    });
+  });
+
+  test('prints a concise error for unknown flags', () => {
+    const result = parseStdioCliArgs(['--definitely-not-a-real-flag'], '0.8.2');
+
+    expect(result.action).toBe('exit');
+    if (result.action !== 'exit') {
+      throw new Error('Expected CLI parsing to exit');
+    }
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      "Unknown option '--definitely-not-a-real-flag'"
+    );
+    expect(result.stderr).not.toContain('TypeError');
+    expect(result.stderr).not.toContain('ERR_PARSE_ARGS_UNKNOWN_OPTION');
+  });
+});

--- a/packages/mcp-server-supabase/src/transports/stdio-cli.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio-cli.ts
@@ -1,0 +1,115 @@
+import { parseArgs } from 'node:util';
+
+export type StdioCliResult =
+  | {
+      action: 'start';
+      apiUrl?: string;
+      cliAccessToken?: string;
+      cliFeatures?: string;
+      projectId?: string;
+      readOnly: boolean;
+    }
+  | {
+      action: 'exit';
+      exitCode: number;
+      stderr?: string;
+      stdout?: string;
+    };
+
+const helpText = `Usage: mcp-server-supabase [options]
+
+Options:
+  --access-token <token>  Supabase personal access token
+  --project-ref <ref>     Supabase project reference
+  --read-only             Restrict the server to read-only tools
+  --api-url <url>         Supabase Management API URL
+  --features <list>       Comma-separated feature list
+  -v, --version           Print the package version
+  -h, --help              Display help for command
+`;
+
+export function parseStdioCliArgs(
+  args: string[],
+  version: string
+): StdioCliResult {
+  try {
+    const {
+      values: {
+        ['access-token']: cliAccessToken,
+        ['project-ref']: projectId,
+        ['read-only']: readOnly,
+        ['api-url']: apiUrl,
+        ['version']: showVersion,
+        ['features']: cliFeatures,
+        ['help']: showHelp,
+      },
+    } = parseArgs({
+      args,
+      options: {
+        ['access-token']: {
+          type: 'string',
+        },
+        ['project-ref']: {
+          type: 'string',
+        },
+        ['read-only']: {
+          type: 'boolean',
+          default: false,
+        },
+        ['api-url']: {
+          type: 'string',
+        },
+        ['version']: {
+          type: 'boolean',
+          short: 'v',
+        },
+        ['features']: {
+          type: 'string',
+        },
+        ['help']: {
+          type: 'boolean',
+          short: 'h',
+        },
+      },
+    });
+
+    if (showHelp) {
+      return {
+        action: 'exit',
+        exitCode: 0,
+        stdout: helpText,
+      };
+    }
+
+    if (showVersion) {
+      return {
+        action: 'exit',
+        exitCode: 0,
+        stdout: `${version}\n`,
+      };
+    }
+
+    return {
+      action: 'start',
+      apiUrl,
+      cliAccessToken,
+      cliFeatures,
+      projectId,
+      readOnly: readOnly ?? false,
+    };
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      error.code === 'ERR_PARSE_ARGS_UNKNOWN_OPTION'
+    ) {
+      return {
+        action: 'exit',
+        exitCode: 1,
+        stderr: `${error.message}\n`,
+      };
+    }
+
+    throw error;
+  }
+}

--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -1,54 +1,28 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { parseArgs } from 'node:util';
 import packageJson from '../../package.json' with { type: 'json' };
 import { createSupabaseApiPlatform } from '../platform/api-platform.js';
 import { createSupabaseMcpServer } from '../server.js';
+import { parseStdioCliArgs } from './stdio-cli.js';
 import { parseList } from './util.js';
 
 const { version } = packageJson;
 
 async function main() {
-  const {
-    values: {
-      ['access-token']: cliAccessToken,
-      ['project-ref']: projectId,
-      ['read-only']: readOnly,
-      ['api-url']: apiUrl,
-      ['version']: showVersion,
-      ['features']: cliFeatures,
-    },
-  } = parseArgs({
-    options: {
-      ['access-token']: {
-        type: 'string',
-      },
-      ['project-ref']: {
-        type: 'string',
-      },
-      ['read-only']: {
-        type: 'boolean',
-        default: false,
-      },
-      ['api-url']: {
-        type: 'string',
-      },
-      ['version']: {
-        type: 'boolean',
-      },
-      ['features']: {
-        type: 'string',
-      },
-    },
-  });
+  const cli = parseStdioCliArgs(process.argv.slice(2), version);
 
-  if (showVersion) {
-    console.log(version);
-    process.exit(0);
+  if (cli.action === 'exit') {
+    if (cli.stdout) {
+      process.stdout.write(cli.stdout);
+    }
+    if (cli.stderr) {
+      process.stderr.write(cli.stderr);
+    }
+    process.exit(cli.exitCode);
   }
 
-  const accessToken = cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
+  const accessToken = cli.cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
 
   if (!accessToken) {
     console.error(
@@ -57,17 +31,17 @@ async function main() {
     process.exit(1);
   }
 
-  const features = cliFeatures ? parseList(cliFeatures) : undefined;
+  const features = cli.cliFeatures ? parseList(cli.cliFeatures) : undefined;
 
   const platform = createSupabaseApiPlatform({
     accessToken,
-    apiUrl,
+    apiUrl: cli.apiUrl,
   });
 
   const server = createSupabaseMcpServer({
     platform,
-    projectId,
-    readOnly,
+    projectId: cli.projectId,
+    readOnly: cli.readOnly,
     features,
   });
 


### PR DESCRIPTION
## Summary
- add stdio CLI handling for --help/-h before the server starts
- keep --version working and add -v
- normalize unknown top-level flags to a concise non-zero CLI error instead of a parseArgs stack trace

Fixes #296.

## Verification
- CI=true pnpm exec vitest --run src/transports/stdio-cli.test.ts --project unit from packages/mcp-server-supabase
- CI=true pnpm --filter @supabase/mcp-server-supabase typecheck
- pnpm exec biome check packages/mcp-server-supabase/src/transports/stdio.ts packages/mcp-server-supabase/src/transports/stdio-cli.ts packages/mcp-server-supabase/src/transports/stdio-cli.test.ts
- pnpm --filter @supabase/mcp-server-supabase build
- node packages/mcp-server-supabase/dist/transports/stdio.js --help
- node packages/mcp-server-supabase/dist/transports/stdio.js -h
- node packages/mcp-server-supabase/dist/transports/stdio.js --version
- node packages/mcp-server-supabase/dist/transports/stdio.js -v
- node packages/mcp-server-supabase/dist/transports/stdio.js --definitely-not-a-real-flag exits 1 with concise error
- git diff --check