### PR TITLE
fix: normalize debug feature alias in tool schemas

### DIFF
--- a/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
@@ -51,6 +51,21 @@ describe('createToolSchemas', () => {
       expectTypeOf(schemas).toHaveProperty('search_docs');
       expectTypeOf(schemas).not.toHaveProperty('execute_sql');
     });
+
+    test('normalizes deprecated feature names', () => {
+      const deprecatedSchemas = createToolSchemas({
+        features: ['debug'] as any,
+      });
+      const currentSchemas = createToolSchemas({ features: ['debugging'] });
+
+      expect(Object.keys(deprecatedSchemas).sort()).toEqual(
+        Object.keys(currentSchemas).sort()
+      );
+      expect(Object.keys(deprecatedSchemas).sort()).toEqual([
+        'get_advisors',
+        'get_logs',
+      ]);
+    });
   });
 
   describe('PROJECT_SCOPED_OVERRIDES completeness', () => {

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.ts
@@ -1,5 +1,9 @@
 import type { z } from 'zod/v4';
-import { CURRENT_FEATURE_GROUPS, type FeatureGroup } from '../types.js';
+import {
+  CURRENT_FEATURE_GROUPS,
+  featureGroupSchema,
+  type FeatureGroup,
+} from '../types.js';
 import { accountToolDefs } from './account-tools.js';
 import { branchingToolDefs } from './branching-tools.js';
 import { databaseToolDefs } from './database-operation-tools.js';
@@ -247,7 +251,9 @@ export function createToolSchemas<
   readOnly?: ReadOnly;
 }): ToolSchemasFor<Features[number], ProjectScoped, ReadOnly> {
   const enabledFeatures = new Set<string>(
-    options?.features ?? CURRENT_FEATURE_GROUPS
+    (options?.features ?? CURRENT_FEATURE_GROUPS).map((feature) =>
+      featureGroupSchema.parse(feature)
+    )
   );
   const projectScoped = options?.projectScoped ?? false;
   const readOnly = options?.readOnly ?? false;


### PR DESCRIPTION
## What

Normalizes feature names in `createToolSchemas()` through the same `featureGroupSchema` used by the server. This keeps the exported schema helper aligned with server feature parsing for the deprecated `debug` alias.

Fixes #321.

## Tests

- `CI=1 ./node_modules/.bin/vitest run --project unit src/tools/tool-schemas.test.ts` from `packages/mcp-server-supabase`
- `./node_modules/.bin/tsc --noEmit` from `packages/mcp-server-supabase`
- `./node_modules/.bin/biome check packages/mcp-server-supabase/src/tools/tool-schemas.ts packages/mcp-server-supabase/src/tools/tool-schemas.test.ts`
- `git diff --check`