### PR TITLE
docs: breaking change strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Follow the [expand and contract pattern](https://martinfowler.com/bliki/Parallel
 
 **Update the ChatGPT plugin submission when published metadata changes**
 
-Create a new plugin submission via the [OpenAI plugin dashboard](https://platform.openai.com/plugins). OpenAI's [chatgpt-app-submission skill](https://github.com/openai/plugins/blob/main/plugins/openai-developers/skills/chatgpt-app-submission/SKILL.md) can help prepare the submission metadata.
+Create a new plugin submission via the [OpenAI plugin dashboard](https://platform.openai.com/plugins). Note the submission file can contain sensitive test credentials, so prefer making updates by hand.
 
 Server-only fixes that preserve the published contract don't need resubmission.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,42 @@ If the release PR gets into a bad state, close it and manually re-run the workfl
 
 If the workflow creates GitHub releases and tags but fails before publishing to npm or the MCP registry, re-run the workflow from one of the release tags created by the failed workflow run and enable `force_publish`.
 
+## Breaking changes
+
+Treat `tools/list` as a public API contract.
+
+ChatGPT snapshots MCP metadata during plugin submission. These fields are frozen for published ChatGPT users until a new plugin version is scanned, reviewed, and published:
+
+- Tool list, names, titles, and descriptions
+- Input and output schemas
+- Tool annotations
+- Tool security schemes
+- Tool `_meta` fields
+- MCP server `instructions`
+
+Claude Connectors don't have this constraint. Claude picks up server changes on the next connection, no resubmission or review required ([docs](https://claude.com/docs/connectors/building/after-publishing#update-your-mcp-server)).
+
+**Keep breaking changes backward compatible**
+
+- Add new tools/fields before removing old ones.
+- Make new response fields optional unless every client is ready.
+- Do not rename/remove tools or make schemas stricter in a single release.
+
+**Update docs when the MCP surface changes**
+
+- [supabase.com/mcp](https://supabase.com/mcp) owns the canonical tool list.
+- README should link to that list, not duplicate it.
+- Grep agent skills for exact tool names only when names or behavior change.
+
+**Update the ChatGPT plugin submission when published metadata must change**
+
+- Batch small metadata-only edits (wording tweaks) into the next submission unless they're misleading, safety-relevant, or needed for correct tool selection.
+- To publish: deploy the server change, open the [OpenAI plugin dashboard](https://platform.openai.com/plugins), update the existing Supabase plugin draft, scan the production MCP endpoint, fix validation issues, submit for review, then publish after approval.
+
+Server-only fixes that preserve the published contract don't need resubmission.
+
+If a deployed change breaks the published ChatGPT contract, roll back the server change rather than waiting on review.
+
 ## Manual MCP registry publish (optional)
 
 This is only needed if the automated publish failed or needs to be re-run manually. The MCP registry stores metadata about the server (defined in `packages/mcp-server-supabase/server.json`) — it does not host the server itself.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,33 +66,32 @@ If the workflow creates GitHub releases and tags but fails before publishing to 
 
 Treat `tools/list` as a public API contract.
 
-ChatGPT snapshots MCP metadata during plugin submission. These fields are frozen for published ChatGPT users until a new plugin version is scanned, reviewed, and published:
+ChatGPT snapshots MCP metadata during plugin submission. Several fields are frozen for published ChatGPT users until a new plugin version is published, including:
 
 - Tool list, names, titles, and descriptions
 - Input and output schemas
 - Tool annotations
-- Tool security schemes
 - Tool `_meta` fields
 - MCP server `instructions`
 
-Claude Connectors don't have this constraint. Claude picks up server changes on the next connection, no resubmission or review required ([docs](https://claude.com/docs/connectors/building/after-publishing#update-your-mcp-server)).
+See OpenAI's [Ongoing Maintenance](https://developers.openai.com/apps-sdk/deploy/submission#ongoing-maintenance) docs for a more complete overview of frozen fields.
+
+Claude Connectors don't have this constraint, and will pick up server changes on the next connection without needing resubmission ([docs](https://claude.com/docs/connectors/building/after-publishing#update-your-mcp-server)).
 
 **Keep breaking changes backward compatible**
 
-- Add new tools/fields before removing old ones.
-- Make new response fields optional unless every client is ready.
-- Do not rename/remove tools or make schemas stricter in a single release.
+Follow the [expand and contract pattern](https://martinfowler.com/bliki/ParallelChange.html) (aka Parallel Change):
+
+- **Expand:** add new tools/fields alongside the old ones. New fields must be optional, so clients still on the frozen schema keep validating. Don't touch the optionality of existing fields.
+- **Contract:** only remove the old tools/fields once the new version is published, so no frozen client can still depend on them.
 
 **Update docs when the MCP surface changes**
 
-- [supabase.com/mcp](https://supabase.com/mcp) owns the canonical tool list.
-- README should link to that list, not duplicate it.
-- Grep agent skills for exact tool names only when names or behavior change.
+[supabase.com/mcp](https://supabase.com/mcp) owns the canonical tool list, update it as needed for changes to tools or configuration options. [Agent skills](https://github.com/supabase/agent-skills) should generally reference MCP workflows instead of specific tool names, but double check for wording when names or behavior change.
 
-**Update the ChatGPT plugin submission when published metadata must change**
+**Update the ChatGPT plugin submission when published metadata changes**
 
-- Batch small metadata-only edits (wording tweaks) into the next submission unless they're misleading, safety-relevant, or needed for correct tool selection.
-- To publish: deploy the server change, open the [OpenAI plugin dashboard](https://platform.openai.com/plugins), update the existing Supabase plugin draft, scan the production MCP endpoint, fix validation issues, submit for review, then publish after approval.
+Create a new plugin submission via the [OpenAI plugin dashboard](https://platform.openai.com/plugins). OpenAI's [chatgpt-app-submission skill](https://github.com/openai/plugins/blob/main/plugins/openai-developers/skills/chatgpt-app-submission/SKILL.md) can help prepare the submission metadata.
 
 Server-only fixes that preserve the published contract don't need resubmission.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![supabase-mcp-demo](https://github.com/user-attachments/assets/3fce101a-b7d4-482f-9182-0be70ed1ad56)
 
-The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) standardizes how Large Language Models (LLMs) talk to external services like Supabase. It connects AI assistants directly with your Supabase project and allows them to perform tasks like managing tables, fetching config, and querying data. See the [full list of tools](#tools).
+The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) standardizes how Large Language Models (LLMs) talk to external services like Supabase. It connects AI assistants directly with your Supabase project and allows them to perform tasks like managing tables, fetching config, and querying data. See the [full list of tools](https://supabase.com/mcp#available-tools).
 
 ## Setup
 
@@ -44,140 +44,11 @@ If you're running Supabase locally with [Supabase CLI](https://supabase.com/docs
 
 For [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting/docker), check the [Enabling MCP server](https://supabase.com/docs/guides/self-hosting/enable-mcp) page. Currently, the MCP Server in self-hosted environments offers a limited subset of tools and no OAuth 2.1.
 
-## Options
+## Configuration options and tools
 
-The following options are configurable as URL query parameters:
+The Supabase MCP server provides tools for your agents to manage Supabase projects, query and migrate databases, deploy Edge Functions, check advisors, and more. See the [Supabase MCP Server](https://supabase.com/mcp) docs for the full list of [available tools](https://supabase.com/mcp#available-tools) and [configuration options](https://supabase.com/mcp#configuration-options).
 
-- `read_only`: Used to restrict the server to read-only queries and tools. Recommended by default. See [read-only mode](#read-only-mode).
-- `project_ref`: Used to scope the server to a specific project. Recommended by default. If you omit this, the server will have access to all projects in your Supabase account. See [project scoped mode](#project-scoped-mode).
-- `features`: Used to specify which tool groups to enable. See [feature groups](#feature-groups).
-
-When using the URL in the dashboard or docs, these parameters will be populated for you.
-
-### Project scoped mode
-
-Without project scoping, the MCP server will have access to all projects in your Supabase organization. We recommend you restrict the server to a specific project by setting the `project_ref` query parameter in the server URL:
-
-```
-https://mcp.supabase.com/mcp?project_ref=<project-ref>
-```
-
-Replace `<project-ref>` with the ID of your project. You can find this under **Project ID** in your Supabase [project settings](https://supabase.com/dashboard/project/_/settings/general).
-
-After scoping the server to a project, [account-level](#project-management) tools like `list_projects` and `list_organizations` will no longer be available. The server will only have access to the specified project and its resources.
-
-### Read-only mode
-
-To restrict the Supabase MCP server to read-only queries, set the `read_only` query parameter in the server URL:
-
-```
-https://mcp.supabase.com/mcp?read_only=true
-```
-
-We recommend enabling this setting by default. This prevents write operations on any of your databases by executing SQL as a read-only Postgres user (via `execute_sql`). All other mutating tools are disabled in read-only mode, including:
-`apply_migration`
-`create_project`
-`pause_project`
-`restore_project`
-`deploy_edge_function`
-`create_branch`
-`delete_branch`
-`merge_branch`
-`reset_branch`
-`rebase_branch`
-`update_storage_config`.
-
-### Feature groups
-
-You can enable or disable specific tool groups by passing the `features` query parameter to the MCP server. This allows you to customize which tools are available to the LLM. For example, to enable only the [database](#database) and [docs](#knowledge-base) tools, you would specify the server URL as:
-
-```
-https://mcp.supabase.com/mcp?features=database,docs
-```
-
-Available groups are: [`account`](#account), [`docs`](#knowledge-base), [`database`](#database), [`debugging`](#debugging), [`development`](#development), [`functions`](#edge-functions), [`storage`](#storage), and [`branching`](#branching-experimental-requires-a-paid-plan).
-
-If this parameter is not set, the default feature groups are: `account`, `database`, `debugging`, `development`, `docs`, `functions`, and `branching`.
-
-## Tools
-
-_**Note:** This server is pre-1.0, so expect some breaking changes between versions. Since LLMs will automatically adapt to the tools available, this shouldn't affect most users._
-
-The following Supabase tools are available to the LLM, [grouped by feature](#feature-groups).
-
-#### Account
-
-Enabled by default when no `project_ref` is set. Use `account` to target this group of tools with the [`features`](#feature-groups) option.
-
-_**Note:** these tools will be unavailable if the server is [scoped to a project](#project-scoped-mode)._
-
-- `list_projects`: Lists all Supabase projects for the user.
-- `get_project`: Gets details for a project.
-- `create_project`: Creates a new Supabase project.
-- `pause_project`: Pauses a project.
-- `restore_project`: Restores a project.
-- `list_organizations`: Lists all organizations that the user is a member of.
-- `get_organization`: Gets details for an organization.
-- `get_cost`: Gets the cost of a new project or branch for an organization.
-- `confirm_cost`: Confirms the user's understanding of new project or branch costs. This is required to create a new project or branch.
-
-#### Knowledge Base
-
-Enabled by default. Use `docs` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `search_docs`: Searches the Supabase documentation for up-to-date information. LLMs can use this to find answers to questions or learn how to use specific features.
-
-#### Database
-
-Enabled by default. Use `database` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `list_tables`: Lists all tables within the specified schemas.
-- `list_extensions`: Lists all extensions in the database.
-- `list_migrations`: Lists all migrations in the database.
-- `apply_migration`: Applies a SQL migration to the database. SQL passed to this tool will be tracked within the database, so LLMs should use this for DDL operations (schema changes).
-- `execute_sql`: Executes raw SQL in the database. LLMs should use this for regular queries that don't change the schema.
-
-#### Debugging
-
-Enabled by default. Use `debugging` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `get_logs`: Gets logs for a Supabase project by service type (api, postgres, edge functions, auth, storage, realtime). LLMs can use this to help with debugging and monitoring service performance.
-- `get_advisors`: Gets a list of advisory notices for a Supabase project. LLMs can use this to check for security vulnerabilities or performance issues.
-
-#### Development
-
-Enabled by default. Use `development` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `get_project_url`: Gets the API URL for a project.
-- `get_publishable_keys`: Gets the anonymous API keys for a project. Returns an array of client-safe API keys including legacy anon keys and modern publishable keys. Publishable keys are recommended for new applications.
-- `generate_typescript_types`: Generates TypeScript types based on the database schema. LLMs can save this to a file and use it in their code.
-
-#### Edge Functions
-
-Enabled by default. Use `functions` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `list_edge_functions`: Lists all Edge Functions in a Supabase project.
-- `get_edge_function`: Retrieves file contents for an Edge Function in a Supabase project.
-- `deploy_edge_function`: Deploys a new Edge Function to a Supabase project. LLMs can use this to deploy new functions or update existing ones.
-
-#### Branching (Experimental, requires a paid plan)
-
-Enabled by default. Use `branching` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `create_branch`: Creates a development branch with migrations from production branch.
-- `list_branches`: Lists all development branches.
-- `delete_branch`: Deletes a development branch.
-- `merge_branch`: Merges migrations and edge functions from a development branch to production.
-- `reset_branch`: Resets migrations of a development branch to a prior version.
-- `rebase_branch`: Rebases development branch on production to handle migration drift.
-
-#### Storage
-
-Disabled by default to reduce tool count. Use `storage` to target this group of tools with the [`features`](#feature-groups) option.
-
-- `list_storage_buckets`: Lists all storage buckets in a Supabase project.
-- `get_storage_config`: Gets the storage config for a Supabase project.
-- `update_storage_config`: Updates the storage config for a Supabase project (requires a paid plan).
+The docs also feature an interactive URL builder to populate configuration options for you.
 
 ## Security risks
 
@@ -218,7 +89,7 @@ for (const step of await result.steps) {
 
 `createToolSchemas()` accepts similar filtering options as the MCP server's URL parameters:
 
-- `features`: Restrict to specific [feature groups](#feature-groups) (e.g. `['database', 'docs']`). Defaults to all default feature groups.
+- `features`: Restrict to specific [feature groups](https://supabase.com/mcp#configuration-options) (e.g. `['database', 'docs']`). Defaults to all default feature groups.
 - `projectScoped`: When `true`, omits `project_id` from tool input schemas and excludes account-level tools — use when connecting to a server configured with `project_ref`. Defaults to `false`.
 - `readOnly`: When `true`, excludes mutating tools — use when connecting to a server configured with `read_only=true`. Defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting/docker)
 
 ## Configuration options and tools
 
-The Supabase MCP server provides tools for your agents to manage Supabase projects, query and migrate databases, deploy Edge Functions, check advisors, and more. See the [Supabase MCP Server](https://supabase.com/mcp) docs for the full list of [available tools](https://supabase.com/mcp#available-tools) and [configuration options](https://supabase.com/mcp#configuration-options).
+See the [Supabase MCP Server](https://supabase.com/mcp) docs for the full list of [available tools](https://supabase.com/mcp#available-tools) and [configuration options](https://supabase.com/mcp#configuration-options).
 
 The docs also feature an interactive URL builder to populate configuration options for you.
 


### PR DESCRIPTION
Documents a breaking change strategy for the MCP server in `CONTRIBUTING.md`, as we prepare for various tool changes and strict output schemas.

The main risk is our ChatGPT Plugin (previously App) submission which freezes server metadata including the tools list, see their [Ongoing Maintenance](https://developers.openai.com/apps-sdk/deploy/submission#ongoing-maintenance) docs. I'm advising a parallel change / expand-and-contract workflow to keep changes backwards compatible.

Claude Connectors don't appear to have this risk. From [Manage your listing after publishing](https://claude.com/docs/connectors/building/after-publishing#update-your-mcp-server):

> An MCP server is a live API. To add, change, or remove tools, deploy the change to your server—no resubmission to Anthropic is required, and there is no scheduled re-review. Claude picks up the new tool surface on the next connection.

This also removes the duplicated tools/options list from the README in favor of linking to [supabase.com/mcp](https://supabase.com/mcp) as the canonical source to prevent drift.

Closes AI-900
