### PR TITLE
feat: hide tools from tools/list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,10 @@ Follow the [expand and contract pattern](https://martinfowler.com/bliki/Parallel
 - **Expand:** add new tools/fields alongside the old ones. New fields must be optional, so clients still on the frozen schema keep validating. Don't touch the optionality of existing fields.
 - **Contract:** only remove the old tools/fields once the new version is published, so no frozen client can still depend on them.
 
+**Version the break at contract, not expand**
+
+The expand step adds things without removing anything, so it's safe to release as a normal `feat`/`fix` commit - nothing that already worked stops working. The contract step is the one that actually removes a tool/field, so that's where the real break happens: mark that commit accordingly (e.g. `feat!:` or a `BREAKING CHANGE:` footer) so the changelog and version bump reflect it, even though the wire-level (`tools/list`) change may have quietly landed one or more releases earlier at expand time.
+
 **Deprecating a tool**
 
 1. **Expand:** add the replacement tool, then mark the old one `hidden: true` (with a comment noting its replacement) instead of removing it right away:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,24 @@ Follow the [expand and contract pattern](https://martinfowler.com/bliki/Parallel
 - **Expand:** add new tools/fields alongside the old ones. New fields must be optional, so clients still on the frozen schema keep validating. Don't touch the optionality of existing fields.
 - **Contract:** only remove the old tools/fields once the new version is published, so no frozen client can still depend on them.
 
+**Deprecating a tool**
+
+1. **Expand:** add the replacement tool, then mark the old one `hidden: true` (with a comment noting its replacement) instead of removing it right away:
+
+   ```ts
+   export const someToolDefs = {
+     new_tool: { ... },
+     old_tool: {
+       ...,
+       hidden: true, // replaced by new_tool, remove once a new ChatGPT submission has gone out
+     },
+   } satisfies ToolDefs;
+   ```
+
+   This drops the old tool from `tools/list` for live clients while keeping it fully callable via `tools/call`, so the frozen ChatGPT plugin keeps working.
+
+2. **Contract:** once a new ChatGPT plugin submission has gone out, delete the old tool definition entirely.
+
 **Update docs when the MCP surface changes**
 
 [supabase.com/mcp](https://supabase.com/mcp) owns the canonical tool list, update it as needed for changes to tools or configuration options. [Agent skills](https://github.com/supabase/agent-skills) should generally reference MCP workflows instead of specific tool names, but double check for wording when names or behavior change.

--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -2940,13 +2940,18 @@ export interface components {
             /** @enum {string} */
             status: "stored" | "applied";
         };
+        /** @example {
+         *       "root_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+         *     } */
         PgsodiumConfigResponse: {
+            /** @description The pgsodium root key: 32 bytes, hex-encoded (64 characters). */
             root_key: string;
         };
         /** @example {
-         *       "root_key": "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+         *       "root_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
          *     } */
         UpdatePgsodiumConfigBody: {
+            /** @description The pgsodium root key: 32 bytes, hex-encoded (64 characters). */
             root_key: string;
         };
         PostgrestConfigWithJWTSecretResponse: {
@@ -3038,6 +3043,22 @@ export interface components {
             /** @enum {string} */
             status: "not-used" | "custom-domain-used" | "active";
             custom_domain?: string;
+        };
+        PlanGateErrorBody: {
+            /** @description Human-readable explanation of the plan gate */
+            message: string;
+            /** @description Present on entitlement denials. Other errors with this status code (validation, billing state) carry only message. */
+            error?: {
+                /**
+                 * @description Machine-readable marker for plan-gated denials
+                 * @enum {string}
+                 */
+                code: "entitlement_required";
+                /** @description Entitlement feature key that failed the check */
+                feature: string;
+                /** @description Billing page URL for the organization, present when the org is resolvable */
+                upgrade_url?: string;
+            };
         };
         /** @example {
          *       "vanity_subdomain": "acme-prod"
@@ -7940,7 +7961,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PlanGateErrorBody"];
+                };
             };
             /** @description Unauthorized */
             401: {
@@ -8049,7 +8072,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PlanGateErrorBody"];
+                };
             };
             /** @description Unauthorized */
             401: {
@@ -8110,7 +8135,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PlanGateErrorBody"];
+                };
             };
             /** @description Unauthorized */
             401: {
@@ -8430,7 +8457,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PlanGateErrorBody"];
+                };
             };
             /** @description Forbidden action */
             403: {
@@ -12909,7 +12938,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PlanGateErrorBody"];
+                };
             };
             /** @description Forbidden action */
             403: {
@@ -12984,7 +13015,9 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["PlanGateErrorBody"];
+                };
             };
             /** @description Forbidden action */
             403: {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -3112,7 +3112,7 @@ describe('tools', () => {
     }
   });
 
-  test('all tools are included in supabaseMcpToolSchemas registry', async () => {
+  test('all tools are included in supabaseMcpToolSchemas registry, including hidden tools', async () => {
     // Enable all features to ensure we check all possible tools
     const { client } = await setup({
       features: [
@@ -3137,8 +3137,11 @@ describe('tools', () => {
       ).toHaveProperty(tool.name);
     }
 
-    // Also verify that the registry doesn't have extra entries
-    // (tools that don't exist in the server)
+    // Also verify that the registry doesn't have unexpected extra entries
+    // (tools that don't exist in the server). A registry entry is allowed to
+    // be missing from tools/list only if its tool def is marked `hidden` —
+    // it stays in the registry for typed access while being delisted from
+    // live discovery (see CONTRIBUTING.md's tool deprecation guidance).
     const registryToolNames = Object.keys(supabaseMcpToolSchemas);
     const serverToolNames = tools.map((t) => t.name);
 
@@ -3146,9 +3149,15 @@ describe('tools', () => {
       (name) => !serverToolNames.includes(name)
     );
 
+    const unexpectedExtraTools = extraToolsInRegistry.filter(
+      (name) =>
+        !supabaseMcpToolSchemas[name as keyof typeof supabaseMcpToolSchemas]
+          .hidden
+    );
+
     expect(
-      extraToolsInRegistry,
-      'Registry should not contain tools that are not in the MCP server when all features are enabled'
+      unexpectedExtraTools,
+      'Registry should not contain tools that are not in the MCP server when all features are enabled, unless the tool is marked `hidden`'
     ).toEqual([]);
   });
 

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
@@ -1,5 +1,34 @@
+import { z } from 'zod/v4';
 import { describe, expect, expectTypeOf, test } from 'vitest';
-import { createToolSchemas, supabaseMcpToolSchemas } from './tool-schemas.js';
+import {
+  createToolSchemas,
+  defsToSchemas,
+  supabaseMcpToolSchemas,
+} from './tool-schemas.js';
+import type { ToolDefs } from './util.js';
+
+describe('defsToSchemas', () => {
+  test('propagates hidden from a tool def into its schema entry', () => {
+    const defs = {
+      visible_tool: {
+        parameters: z.object({}),
+        outputSchema: z.object({}),
+        annotations: { title: 'Visible tool' },
+      },
+      hidden_tool: {
+        parameters: z.object({}),
+        outputSchema: z.object({}),
+        annotations: { title: 'Hidden tool' },
+        hidden: true,
+      },
+    } satisfies ToolDefs;
+
+    const schemas = defsToSchemas(defs);
+
+    expect(schemas.visible_tool.hidden).toBeUndefined();
+    expect(schemas.hidden_tool.hidden).toBe(true);
+  });
+});
 
 describe('createToolSchemas', () => {
   describe('no options (default)', () => {

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.ts
@@ -20,10 +20,14 @@ type DefsToSchemas<T extends ToolDefs> = {
     }
       ? R
       : undefined;
+    hidden: T[K] extends { hidden: infer H extends boolean } ? H : undefined;
   };
 };
 
-function defsToSchemas<const T extends ToolDefs>(defs: T): DefsToSchemas<T> {
+/** Exported for testing */
+export function defsToSchemas<const T extends ToolDefs>(
+  defs: T
+): DefsToSchemas<T> {
   return Object.fromEntries(
     Object.entries(defs).map(
       ([name, { parameters: inputSchema, description: _, ...rest }]) => [
@@ -39,6 +43,8 @@ type SchemaEntry = {
   outputSchema: z.ZodObject<any>;
   annotations: ToolDefs[string]['annotations'];
   readOnlyBehavior?: 'exclude' | 'adapt';
+  /** If true, the tool is excluded from `tools/list` but kept in this registry for typed access. */
+  hidden?: boolean;
 };
 
 /**

--- a/packages/mcp-server-supabase/src/tools/util.test.ts
+++ b/packages/mcp-server-supabase/src/tools/util.test.ts
@@ -1,0 +1,132 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  CallToolResultSchema,
+  type CallToolRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+import { createMcpServer, StreamTransport } from '@supabase/mcp-utils';
+import { describe, expect, test } from 'vitest';
+import { z } from 'zod/v4';
+import { MCP_CLIENT_NAME, MCP_CLIENT_VERSION } from '../../test/mocks.js';
+import { injectableTool } from './util.js';
+
+/**
+ * Sets up an MCP client and server for testing a set of tools.
+ */
+async function setup(tools: Record<string, ReturnType<typeof injectableTool>>) {
+  const clientTransport = new StreamTransport();
+  const serverTransport = new StreamTransport();
+
+  clientTransport.readable.pipeTo(serverTransport.writable);
+  serverTransport.readable.pipeTo(clientTransport.writable);
+
+  const client = new Client(
+    { name: MCP_CLIENT_NAME, version: MCP_CLIENT_VERSION },
+    { capabilities: {} }
+  );
+
+  const server = createMcpServer({
+    name: 'test-server',
+    version: '0.0.0',
+    tools,
+  });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  /**
+   * Calls a tool with the given parameters.
+   *
+   * Wrapper around the `client.callTool` method to handle the response and errors.
+   */
+  async function callTool(params: CallToolRequest['params']) {
+    const output = await client.callTool(params);
+    const { content } = CallToolResultSchema.parse(output);
+    const [textContent] = content;
+
+    if (!textContent || textContent.type !== 'text') {
+      throw new Error('tool result content is not text');
+    }
+
+    const result = JSON.parse(textContent.text);
+
+    if (output.isError) {
+      throw new Error(result.error.message);
+    }
+
+    return result;
+  }
+
+  return { client, callTool };
+}
+
+describe('injectableTool', () => {
+  test('hidden propagates to tools/list when no parameters are injected, but tool remains callable', async () => {
+    const { client, callTool } = await setup({
+      visible_tool: injectableTool({
+        description: 'A visible tool',
+        annotations: {
+          title: 'Visible tool',
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
+        parameters: z.object({ foo: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        execute: async ({ foo }) => ({ value: foo }),
+      }),
+      hidden_tool: injectableTool({
+        description: 'A hidden tool',
+        hidden: true,
+        annotations: {
+          title: 'Hidden tool',
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
+        parameters: z.object({ foo: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        execute: async ({ foo }) => ({ value: foo }),
+      }),
+    });
+
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
+
+    expect(toolNames).toContain('visible_tool');
+    expect(toolNames).not.toContain('hidden_tool');
+
+    await expect(
+      callTool({ name: 'hidden_tool', arguments: { foo: 'bar' } })
+    ).resolves.toEqual({ value: 'bar' });
+  });
+
+  test('hidden propagates to tools/list when parameters are injected, but tool remains callable', async () => {
+    const { client, callTool } = await setup({
+      hidden_tool: injectableTool({
+        description: 'A hidden tool',
+        hidden: true,
+        annotations: {
+          title: 'Hidden tool',
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: false,
+        },
+        parameters: z.object({ project_id: z.string(), foo: z.string() }),
+        outputSchema: z.object({ value: z.string() }),
+        inject: { project_id: 'abc' },
+        execute: async ({ foo }) => ({ value: foo }),
+      }),
+    });
+
+    const { tools } = await client.listTools();
+
+    expect(tools.map((tool) => tool.name)).not.toContain('hidden_tool');
+
+    await expect(
+      callTool({ name: 'hidden_tool', arguments: { foo: 'bar' } })
+    ).resolves.toEqual({ value: 'bar' });
+  });
+});

--- a/packages/mcp-server-supabase/src/tools/util.ts
+++ b/packages/mcp-server-supabase/src/tools/util.ts
@@ -9,6 +9,8 @@ export type ToolDef = {
   annotations: Annotations;
   /** 'adapt' = stays available in read-only mode, adapts behavior. 'exclude' (default) = removed from tool list. */
   readOnlyBehavior?: 'exclude' | 'adapt';
+  /** If true, excludes the tool from `tools/list` while keeping it callable via `tools/call`. */
+  hidden?: boolean;
 };
 
 export type ToolDefs = Record<string, ToolDef>;
@@ -41,6 +43,7 @@ export function injectableTool<
   annotations,
   parameters,
   outputSchema,
+  hidden,
   inject,
   execute,
 }: InjectableTool<Params, OutputSchema, Injected>) {
@@ -51,6 +54,7 @@ export function injectableTool<
       annotations,
       parameters,
       outputSchema,
+      hidden,
       execute,
     });
   }
@@ -77,6 +81,7 @@ export function injectableTool<
     annotations,
     parameters: cleanParametersSchema,
     outputSchema,
+    hidden,
     execute: executeWithInjection,
   });
 }

--- a/packages/mcp-utils/src/server.test.ts
+++ b/packages/mcp-utils/src/server.test.ts
@@ -227,6 +227,47 @@ describe('tools', () => {
     expect(onToolCall.mock.results[0]?.type).toBe('throw');
   });
 
+  test('hidden tool is excluded from tools/list but still callable via tools/call', async () => {
+    const server = createMcpServer({
+      name: 'test-server',
+      version: '0.0.0',
+      tools: {
+        visible_tool: tool({
+          description: 'A visible tool',
+          parameters: z.object({ foo: z.string() }),
+          outputSchema: z.object({ value: z.string() }),
+          execute: async ({ foo }) => {
+            return { value: foo };
+          },
+        }),
+        hidden_tool: tool({
+          description: 'A hidden tool',
+          hidden: true,
+          parameters: z.object({ foo: z.string() }),
+          outputSchema: z.object({ value: z.string() }),
+          execute: async ({ foo }) => {
+            return { value: foo };
+          },
+        }),
+      },
+    });
+
+    const { client, callTool } = await setup({ server });
+
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name);
+
+    expect(toolNames).toEqual(['visible_tool']);
+    expect(toolNames).not.toContain('hidden_tool');
+
+    const result = await callTool({
+      name: 'hidden_tool',
+      arguments: { foo: 'bar' },
+    });
+
+    expect(result).toEqual({ value: 'bar' });
+  });
+
   test('tools use draft-07 JSON Schema', async () => {
     const server = createMcpServer({
       name: 'test-server',

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -60,6 +60,8 @@ export type Tool<
   annotations?: Annotations;
   parameters: Params;
   outputSchema: OutputSchema;
+  /** If true, excludes the tool from `tools/list` while keeping it callable via `tools/call`. */
+  hidden?: boolean;
   execute(params: z.infer<Params>): Promise<z.infer<OutputSchema>>;
 };
 
@@ -453,8 +455,9 @@ export function createMcpServer(options: McpServerOptions) {
 
         return {
           tools: await Promise.all(
-            Object.entries(tools).map(
-              async ([name, { description, annotations, parameters }]) => {
+            Object.entries(tools)
+              .filter(([, tool]) => !tool.hidden)
+              .map(async ([name, { description, annotations, parameters }]) => {
                 const inputSchema = z.toJSONSchema(parameters, {
                   target: 'draft-7',
                 });
@@ -470,8 +473,7 @@ export function createMcpServer(options: McpServerOptions) {
                   // https://github.com/modelcontextprotocol/typescript-sdk/blob/fb07af810b51003c338dc4885a9e42f54519f9af/src/server/mcp.ts#L154
                   inputSchema: inputSchema as McpTool['inputSchema'],
                 };
-              }
-            )
+              })
           ),
         } satisfies ListToolsResult;
       }


### PR DESCRIPTION
Adds a `hidden: true` flag to tool definitions that will hide the tool from `tools/list` calls but allow it to still be callable via `tools/call`. Needed for the [expand+contract](https://github.com/supabase/mcp/blob/main/CONTRIBUTING.md#breaking-changes) breaking change pattern.