### PR TITLE
feat: add --content-api-url flag and SUPABASE_CONTENT_API_URL env var

### DIFF
--- a/packages/mcp-server-supabase/src/transports/stdio.ts
+++ b/packages/mcp-server-supabase/src/transports/stdio.ts
@@ -16,6 +16,7 @@ async function main() {
       ['project-ref']: projectId,
       ['read-only']: readOnly,
       ['api-url']: apiUrl,
+      ['content-api-url']: cliContentApiUrl,
       ['version']: showVersion,
       ['features']: cliFeatures,
     },
@@ -32,6 +33,9 @@ async function main() {
         default: false,
       },
       ['api-url']: {
+        type: 'string',
+      },
+      ['content-api-url']: {
         type: 'string',
       },
       ['version']: {
@@ -59,6 +63,9 @@ async function main() {
 
   const features = cliFeatures ? parseList(cliFeatures) : undefined;
 
+  const contentApiUrl =
+    cliContentApiUrl ?? process.env.SUPABASE_CONTENT_API_URL;
+
   const platform = createSupabaseApiPlatform({
     accessToken,
     apiUrl,
@@ -69,6 +76,7 @@ async function main() {
     projectId,
     readOnly,
     features,
+    contentApiUrl,
   });
 
   const transport = new StdioServerTransport();

--- a/packages/mcp-server-supabase/test/stdio.integration.ts
+++ b/packages/mcp-server-supabase/test/stdio.integration.ts
@@ -1,17 +1,32 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { describe, expect, test } from 'vitest';
-import { ACCESS_TOKEN, MCP_CLIENT_NAME, MCP_CLIENT_VERSION } from './mocks.js';
 import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import gqlmin from 'gqlmin';
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  ACCESS_TOKEN,
+  contentApiMockSchema,
+  MCP_CLIENT_NAME,
+  MCP_CLIENT_VERSION,
+} from './mocks.js';
 
 type SetupOptions = {
   accessToken?: string;
   projectId?: string;
   readOnly?: boolean;
+  contentApiUrl?: string;
+  env?: Record<string, string>;
 };
 
 async function setup(options: SetupOptions = {}) {
-  const { accessToken = ACCESS_TOKEN, projectId, readOnly } = options;
+  const {
+    accessToken = ACCESS_TOKEN,
+    projectId,
+    readOnly,
+    contentApiUrl,
+    env,
+  } = options;
 
   const client = new Client(
     {
@@ -47,14 +62,50 @@ async function setup(options: SetupOptions = {}) {
     args.push('--read-only');
   }
 
+  if (contentApiUrl) {
+    args.push('--content-api-url', contentApiUrl);
+  }
+
   const clientTransport = new StdioClientTransport({
     command,
     args,
+    env: env
+      ? { ...(process.env as Record<string, string>), ...env }
+      : undefined,
   });
 
   await client.connect(clientTransport);
 
   return { client, clientTransport };
+}
+
+/**
+ * Local HTTP stub standing in for the docs Content API, so the spawned
+ * stdio process (a separate OS process, out of reach of msw) has a real
+ * endpoint to hit. Answers the `{ schema }` query with the shared mock
+ * schema and counts every request it receives.
+ */
+async function createContentApiStub() {
+  const hits: URL[] = [];
+
+  const server: Server = createServer((req, res) => {
+    hits.push(new URL(req.url ?? '/', 'http://127.0.0.1'));
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ data: { schema: contentApiMockSchema } }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to bind content API stub');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    hits,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
 }
 
 describe('stdio', () => {
@@ -70,5 +121,58 @@ describe('stdio', () => {
     const setupPromise = setup({ accessToken: null as any });
 
     await expect(setupPromise).rejects.toThrow('MCP error -32000');
+  });
+});
+
+describe('stdio content-api-url', () => {
+  const stubs: Array<{ close: () => Promise<void> }> = [];
+
+  afterEach(async () => {
+    await Promise.all(stubs.splice(0).map((stub) => stub.close()));
+  });
+
+  test('--content-api-url routes content API traffic to the given URL', async () => {
+    const stub = await createContentApiStub();
+    stubs.push(stub);
+
+    const { client } = await setup({ contentApiUrl: stub.url });
+
+    const { tools } = await client.listTools();
+    const searchDocsTool = tools.find((tool) => tool.name === 'search_docs');
+
+    expect(stub.hits.length).toBeGreaterThan(0);
+
+    // The schema embedded in the tool description round-trips from the
+    // stub, proving the flag reached the content API client.
+    expect(searchDocsTool?.description).toContain(gqlmin(contentApiMockSchema));
+  });
+
+  test('SUPABASE_CONTENT_API_URL env var is the fallback', async () => {
+    const stub = await createContentApiStub();
+    stubs.push(stub);
+
+    const { client } = await setup({
+      env: { SUPABASE_CONTENT_API_URL: stub.url },
+    });
+
+    await client.listTools();
+
+    expect(stub.hits.length).toBeGreaterThan(0);
+  });
+
+  test('--content-api-url wins over SUPABASE_CONTENT_API_URL', async () => {
+    const flagStub = await createContentApiStub();
+    const envStub = await createContentApiStub();
+    stubs.push(flagStub, envStub);
+
+    const { client } = await setup({
+      contentApiUrl: flagStub.url,
+      env: { SUPABASE_CONTENT_API_URL: envStub.url },
+    });
+
+    await client.listTools();
+
+    expect(flagStub.hits.length).toBeGreaterThan(0);
+    expect(envStub.hits.length).toBe(0);
   });
 });


### PR DESCRIPTION
Lets the stdio server point the docs Content API client at an alternative GraphQL endpoint instead of the hosted `https://supabase.com/docs/api/graphql` default. Precedence: flag, then env var, then the existing default. Behavior without either is unchanged (the default still applies, and no request is made anywhere new).

**Why**: we are wiring the evals harness so a docs change can be tested end to end before it ships: build a local docs content index, point `search_docs` at it, and run the affected evals against the local mcp build. That needs a supported way to override the Content API endpoint at launch. It also helps anyone running the server against a staging or self-hosted docs deployment.

**What's in here**

* `--content-api-url` CLI flag and `SUPABASE_CONTENT_API_URL` env var on the stdio transport, threaded to the existing `contentApiUrl` option of `createSupabaseMcpServer` (which already carries the hosted default).
* Integration tests (`test/stdio.integration.ts`): the spawned server routes content API traffic to the given URL (asserted by round-tripping the schema into the `search_docs` tool description from a local HTTP stub), the env var works as the fallback, and the flag wins when both are set.

Verified locally: `vitest run --project integration` 5/5, `tsc --noEmit` clean.